### PR TITLE
Stop active turns with Ctrl-C or Escape

### DIFF
--- a/README.org
+++ b/README.org
@@ -112,11 +112,17 @@ If a development checkout has no current fast startup image, the launcher asks
 whether to run its bootstrap. Use =autolith --from-source= to deliberately load
 the checkout without validating or rebuilding that image.
 
-Enter submits. Shift-Enter, Ctrl-Enter, or Alt-Enter inserts a newline. Ctrl-C
-clears a draft or exits from an empty prompt. Press it again while shutdown is
-pending to force exit. Up and Down move across visual input rows before falling
-back to history. Tab and Shift-Tab cycle command suggestions. Messages can be
-drafted and queued while AL is responding. Type =/help= for commands.
+Enter submits. Shift-Enter, Ctrl-Enter, or Alt-Enter inserts a newline. While
+idle, Ctrl-C clears a draft or exits an empty prompt without confirmation.
+During an active turn, Escape or Ctrl-C cancels only that turn without clearing
+the draft or queued messages and returns to the prompt. Only active Ctrl-C opens
+a 2.5-second force-exit window while cancellation is pending; pressing Ctrl-C
+again in that window forces exit and prints the resume command. A turn that
+cancels promptly never announces that window. Escape never forces exit. Up and
+Down move across visual
+input rows before falling back to history. Tab and Shift-Tab cycle command
+suggestions. Messages can be drafted and queued while AL is responding. Type
+=/help= for commands.
 
 * Repository map
 

--- a/docs/autolith-minimal-technical-spec.org
+++ b/docs/autolith-minimal-technical-spec.org
@@ -1248,11 +1248,16 @@ when the primary window is absent, a bounded five-hour estimate may be used.
 Deferred state is private readable data, survives restart, and supports listing
 and exact cancellation.
 
-Ctrl-C with an empty input exits the interface. When the active conversation
-has durable records, shutdown displays the exact command that resumes its
-identifier. An empty conversation has no resume command. While graceful
-cancellation is pending, another Ctrl-C restores the terminal, prints the
-durable resume command when one exists, and forces exit with status 130.
+Ctrl-C with a nonempty idle input clears the draft. With an empty idle input it
+exits the interface without showing a force-exit confirmation. During an active
+turn, Escape or Ctrl-C cancels only that turn, preserves the draft and queued
+messages, and returns to the prompt. Active Ctrl-C shows a transient
+force-exit notice only if cancellation remains pending long enough for the
+option to be useful. A second Ctrl-C within 2.5 seconds
+restores the terminal and forces exit with status 130. The force option ends when
+cancellation finishes. Escape never opens or counts toward forced exit. Ordinary
+shutdown of a conversation with durable records displays the exact command that
+resumes its identifier; an empty conversation has no resume command.
 
 Only command-line =autolith resume= may offer to create a missing root
 =AUTOLITH.org=. A resumed conversation qualifies when its recorded activity

--- a/docs/guide.org
+++ b/docs/guide.org
@@ -246,10 +246,13 @@ commands that cannot run during an active turn are scheduled as follow-up work
 and run at the first opportunity after the current response finishes; the live
 region previews them alongside queued messages, and Tab with an empty draft
 recalls the newest one for editing. Nonmodal commands such as =/compact= retain
-responsive input while they run. Ctrl-C at an empty prompt cancels the active turn, discards
-queued messages, and prints the exact resume command for a durable conversation.
-If clean cancellation cannot finish, another Ctrl-C restores the terminal and
-forces Autolith to exit.
+responsive input while they run. During an active turn, Escape or Ctrl-C
+cancels only the current turn, preserves the draft and queued messages, and
+returns to the prompt. Active Ctrl-C opens a 2.5-second force-exit window while
+cancellation is pending; pressing Ctrl-C again during that window restores the
+terminal and forces Autolith to exit. A cancellation that finishes promptly
+never announces the window it no longer offers. Escape never opens or counts
+toward forced exit.
 
 A fresh conversation stays in memory until its first durable record. Starting
 Autolith and leaving without a message or other saved state creates no
@@ -263,11 +266,19 @@ and they therefore appear below the newer transcript. This display bound does
 not remove anything from durable conversation storage, provider context, or
 compaction input.
 
-=Ctrl-C= clears a nonempty input draft. At an empty prompt it exits Autolith;
-when the conversation is durable, shutdown prints the exact
-=autolith resume ID= command that reopens it. Empty conversations produce no
-resume instruction. Pressing Ctrl-C again while shutdown is pending forces exit
-with status 130 and repeats the durable resume command before leaving.
+=Ctrl-C= clears a nonempty input draft while idle. At an empty prompt it exits
+Autolith without a confirmation notice. During an active turn, Escape or Ctrl-C
+cancels only the current turn without clearing the draft or queued messages and
+returns to the prompt. Active Ctrl-C opens a 2.5-second force-exit window while
+cancellation is pending. Pressing Ctrl-C again during that window restores the
+terminal and forces exit with status 130. The option ends when cancellation
+finishes. Escape never opens or counts toward forced exit.
+
+A hint offering forced exit appears only once a cancellation outlives a brief
+delay, so a turn that stops promptly returns to the prompt without advertising
+an option it has already withdrawn. Every exit of a durable conversation prints
+the exact =autolith resume ID= command that reopens it, including forced exit;
+empty conversations produce no resume instruction.
 
 Conversation identifiers are short, case-sensitive Bitcoin Base58 values such
 as =K-8vQ2mp=. The hyphen after the first character is visual, so both

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -103,10 +103,10 @@
 (define-condition application-turn-cancelled (serious-condition)
   ()
   (:documentation
-   "An internal control condition unwinding a model turn during application exit.")
+   "An internal control condition unwinding the current application turn.")
   (:report (lambda (condition stream)
              (declare (ignore condition))
-             (write-string "The active model turn was cancelled during exit."
+             (write-string "The active turn was cancelled."
                            stream))))
 
 (define-condition application-input-failed (serious-condition)

--- a/src/conversation.lisp
+++ b/src/conversation.lisp
@@ -641,8 +641,8 @@ typing."
    blocks))
 
 (defparameter *conversation-interrupted-tool-output*
-  "Autolith restarted before recording this tool call's result. The call may have changed external state. Inspect the relevant state before deciding whether to retry it."
-  "The provider-visible result synthesized for a tool call interrupted by exit.")
+  "Autolith interrupted this tool call before recording its result. The call may have changed external state. Inspect the relevant state before deciding whether to retry it."
+  "The provider-visible result synthesized for a tool call with an unknown outcome.")
 
 (-> conversation-append-tool-result
     (conversation string

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -402,23 +402,32 @@
                               (application-input-controller--next-work
                                input-controller)
                             while work
-                            do (unwind-protect
-                                   (application-input-controller--run-work
-                                    input-controller work)
-                                 (application-input-controller--finish-work
-                                  input-controller)))
-                        (application-turn-cancelled ()
-                          nil)
+                            do (handler-case
+                                   (unwind-protect
+                                        (progn
+                                          (application-input-controller--run-work
+                                           input-controller work)
+                                          (when
+                                              (application-input-controller--consume-turn-cancellation-delivery-p
+                                               input-controller)
+                                            (error
+                                             (make-condition
+                                              'application-turn-cancelled))))
+                                     (application-input-controller--finish-work
+                                      input-controller))
+                                 (application-turn-cancelled ()
+                                   (conversation--repair-incomplete-tool-calls
+                                    (application-conversation application))
+                                   nil)))
                         (application-input-failed (condition)
                           (application-raise-fatal
                            application
                            (application-input-failed-original-condition
                             condition)
                            (application-input-failed-backtrace condition)))))
-                    (when (eq
-                           (application-input-controller-exit-reason
-                            input-controller)
-                           ':interrupt)
+                    (when (eq (application-input-controller-exit-reason
+                               input-controller)
+                              ':interrupt)
                       (application--present-resume-instruction application)))
                (finish-shutdown)))
         (sb-sys:enable-interrupt sb-unix:sigwinch :default)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -60,8 +60,6 @@
                 #:selector-set-items
                 #:selector-arrange
                 #:selector-handle-event
-                #:enable-keyboard-enhancement
-                #:disable-keyboard-enhancement
                 #:read-event
                 #:sanitize-text
                 #:text-cell-width

--- a/src/responsive-input.lisp
+++ b/src/responsive-input.lisp
@@ -5,6 +5,34 @@
 (defparameter *application-forced-interrupt-status* 130
   "The process status used when repeated Ctrl-C forces exit.")
 
+(defparameter *application-interrupt-exit-window-seconds* 5/2
+  "Seconds in which a second Ctrl-C may force the process to exit.")
+
+(defparameter *application-interrupt-hint-delay-seconds* 1/4
+  "Seconds a cancellation may run before its force-exit hint becomes worth showing.")
+
+(-> application-input-controller--interrupt-window-text () string)
+(defun application-input-controller--interrupt-window-text ()
+  "Return the force-exit window as concise user-facing seconds."
+  (format nil "~,1F" *application-interrupt-exit-window-seconds*))
+
+(-> application-input-controller--forced-exit-text () string)
+(defun application-input-controller--forced-exit-text ()
+  "Return the repeated-Ctrl-C forced-exit explanation."
+  (format nil
+          "Ctrl-C pressed twice within ~A seconds; forcing Autolith to exit."
+          (application-input-controller--interrupt-window-text)))
+
+(-> application-input-controller--monotonic-seconds () real)
+(defun application-input-controller--monotonic-seconds ()
+  "Return monotonically increasing process time in seconds."
+  (/ (get-internal-real-time)
+     (coerce internal-time-units-per-second 'double-float)))
+
+(defparameter *application-interrupt-clock-function*
+  #'application-input-controller--monotonic-seconds
+  "The monotonic clock captured by newly created input controllers.")
+
 (defvar *application-forced-exit-function*
   (lambda (status)
     (sb-ext:exit :code status :abort t))
@@ -52,6 +80,16 @@
     :accessor application-input-controller-active-p
     :type boolean
     :documentation "Whether the main thread is processing one work item.")
+   (turn-cancellation-p
+    :initform nil
+    :accessor application-input-controller-turn-cancellation-p
+    :type boolean
+    :documentation "Whether one active turn is cancelling but not yet finished.")
+   (turn-cancellation-delivery-pending-p
+    :initform nil
+    :accessor application-input-controller-turn-cancellation-delivery-pending-p
+    :type boolean
+    :documentation "Whether the main thread must still receive turn cancellation.")
    (stopping-p
     :initform nil
     :accessor application-input-controller-stopping-p
@@ -88,8 +126,25 @@
     :reader application-input-controller-forced-exit-function
     :type function
     :documentation "The process termination boundary captured before the reader starts.")
+   (interrupt-clock-function
+    :initarg :interrupt-clock-function
+    :initform *application-interrupt-clock-function*
+    :reader application-input-controller-interrupt-clock-function
+    :type function
+    :documentation "The monotonic clock used to recognize repeated Ctrl-C input.")
+   (interrupt-deadline
+    :initform nil
+    :accessor application-input-controller-interrupt-deadline
+    :type (option real)
+    :documentation "The inclusive monotonic deadline for a force-exit Ctrl-C.")
+   (interrupt-hint-time
+    :initform nil
+    :accessor application-input-controller-interrupt-hint-time
+    :type (option real)
+    :documentation "The monotonic time at which an unshown force-exit hint is due.")
    (forced-exit-message
-    :initform "Ctrl-C pressed during shutdown; forcing Autolith to exit."
+    :initform (format nil "~%~A~%"
+                      (application-input-controller--forced-exit-text))
     :accessor application-input-controller-forced-exit-message
     :type string
     :documentation "The complete plain-text notice emitted by forced shutdown.")
@@ -143,7 +198,10 @@ lock because ordinary shutdown may be blocked while either is unavailable."
     (application-input-controller keyword)
     string)
 (defun application-input-controller--forced-exit-message (controller reason)
-  "Return CONTROLLER's forced-exit notice for graceful shutdown REASON."
+  "Return CONTROLLER's forced-exit notice for shutdown or cancellation REASON.
+
+Forced exit abandons an unfinished run, so every reason carries the durable
+resume command that reopens the conversation the run leaves behind."
   (let* ((application
            (application-input-controller-application controller))
          (conversation
@@ -155,33 +213,101 @@ lock because ordinary shutdown may be blocked while either is unavailable."
                 (application--resume-command application))))
     (format nil
             "~%~A~%~@[To resume this conversation, run:~%  ~A~%~]"
-            (if (eq reason ':interrupt)
-                "Ctrl-C pressed again; forcing Autolith to exit."
+            (if (eq reason ':turn-cancellation)
+                (application-input-controller--forced-exit-text)
                 "Ctrl-C pressed during shutdown; forcing Autolith to exit.")
             resume-command)))
 
+(-> application-input-controller--show-interrupt-hint
+    (application-input-controller real)
+    boolean)
+(defun application-input-controller--show-interrupt-hint
+    (controller remaining-seconds)
+  "Show CONTROLLER's force-exit notice for REMAINING-SECONDS and report display.
+
+The notice expires with the force-exit window itself, and a contended
+presentation lock reports no display so a later reader pass can try again."
+  (let* ((application
+           (application-input-controller-application controller))
+         (ui (application-ui application))
+         (shown-p nil))
+    (ignore-errors
+      (setf shown-p
+            (nth-value
+             1
+             (terminal-ui-set-notice
+              ui
+              (format nil
+                      "Press Ctrl-C again within ~A seconds to force exit."
+                      (application-input-controller--interrupt-window-text))
+              :duration-seconds remaining-seconds))))
+    (not (null shown-p))))
+
+(-> application-input-controller--refresh-interrupt-hint
+    (application-input-controller)
+    null)
+(defun application-input-controller--refresh-interrupt-hint (controller)
+  "Show CONTROLLER's force-exit hint once cancellation outlives the hint delay.
+
+Waiting keeps a promptly cancelled turn from flashing an option it no longer
+offers, so the hint appears only while forcing exit is still worth explaining."
+  (let ((hint-time nil)
+        (remaining-seconds nil))
+    (with-lock-held ((application-input-controller-lock controller))
+      (let ((due (application-input-controller-interrupt-hint-time controller))
+            (deadline
+              (application-input-controller-interrupt-deadline controller)))
+        (when (and due deadline)
+          (let ((now
+                  (funcall
+                   (application-input-controller-interrupt-clock-function
+                    controller))))
+            (when (>= now due)
+              (setf hint-time due
+                    remaining-seconds (- deadline now)))))))
+    (when (and remaining-seconds
+               (plusp remaining-seconds)
+               (application-input-controller--show-interrupt-hint
+                controller remaining-seconds))
+      (with-lock-held ((application-input-controller-lock controller))
+        ;; A newer press owns any hint time this pass did not observe.
+        (when (eql (application-input-controller-interrupt-hint-time controller)
+                   hint-time)
+          (setf (application-input-controller-interrupt-hint-time controller)
+                nil)))))
+  nil)
+
 (-> application-input-controller--prepare-shutdown
     (application-input-controller keyword)
-    boolean)
+    (values boolean boolean))
 (defun application-input-controller--prepare-shutdown (controller reason)
-  "Stop ordinary CONTROLLER work and arm its interrupt-only shutdown reader.
+  "Prepare CONTROLLER shutdown and report active and prepared state.
 
-Return true when a model or command turn still needs cancellation."
+The first value reports whether a model or command turn needs cancellation. The
+second reports whether shutdown was prepared."
   (let ((active-p nil)
+        (prepared-p nil)
         (message
           (application-input-controller--forced-exit-message controller reason)))
     (with-lock-held ((application-input-controller-lock controller))
-      (unless (application-input-controller-exit-reason controller)
-        (setf (application-input-controller-exit-reason controller) reason
-              (application-input-controller-forced-exit-message controller)
-              message))
-      (setf (application-input-controller-stopping-p controller) t
-            (application-input-controller-work-items controller) nil
-            (application-input-controller-steering-items controller) nil
-            active-p (application-input-controller-active-p controller))
-      (condition-notify
-       (application-input-controller-condition-variable controller)))
-    active-p))
+      (setf active-p (application-input-controller-active-p controller))
+      (unless (application-input-controller-stopping-p controller)
+        (setf prepared-p t)
+        (unless (application-input-controller-exit-reason controller)
+          (setf (application-input-controller-exit-reason controller) reason
+                (application-input-controller-forced-exit-message controller)
+                message))
+        (when active-p
+          (setf (application-input-controller-turn-cancellation-p controller) t
+                (application-input-controller-turn-cancellation-delivery-pending-p
+                 controller)
+                t))
+        (setf (application-input-controller-stopping-p controller) t
+              (application-input-controller-work-items controller) nil
+              (application-input-controller-steering-items controller) nil)
+        (condition-notify
+         (application-input-controller-condition-variable controller)))
+      (values active-p prepared-p))))
 
 (-> application-input--text ((or string user-message-input)) string)
 (defun application-input--text (input)
@@ -277,6 +403,36 @@ Return true when a model or command turn still needs cancellation."
         (interrupt-thread thread (lambda () (error condition))))))
   nil)
 
+(-> application-input-controller--consume-turn-cancellation-delivery-p
+    (application-input-controller)
+    boolean)
+(defun application-input-controller--consume-turn-cancellation-delivery-p
+    (controller)
+  "Atomically consume and report CONTROLLER's pending cancellation delivery."
+  (eq (sb-ext:compare-and-swap
+       (slot-value controller 'turn-cancellation-delivery-pending-p)
+       t
+       nil)
+      t))
+
+(-> application-input-controller--interrupt-main-for-turn-cancellation
+    (application-input-controller)
+    null)
+(defun application-input-controller--interrupt-main-for-turn-cancellation
+    (controller)
+  "Promptly deliver CONTROLLER's pending turn cancellation to its main thread."
+  (let ((thread (application-input-controller-main-thread controller)))
+    (unless (eq thread (current-thread))
+      (when (thread-alive-p thread)
+        (interrupt-thread
+         thread
+         (lambda ()
+           (when
+               (application-input-controller--consume-turn-cancellation-delivery-p
+                controller)
+             (error (make-condition 'application-turn-cancelled))))))))
+  nil)
+
 (-> application-input-controller--record-failure
     (application-input-controller serious-condition (option string))
     null)
@@ -360,14 +516,105 @@ Return true when a model or command turn still needs cancellation."
     null)
 (defun application-input-controller--request-exit (controller reason)
   "Stop CONTROLLER for REASON, discarding work and cancelling an active turn."
-  (when (application-input-controller--prepare-shutdown controller reason)
-    (handler-case
-        (application-input-controller--interrupt-main
-         controller
-         (make-condition 'application-turn-cancelled))
-      (error ()
-        nil)))
+  (multiple-value-bind (active-p prepared-p)
+      (application-input-controller--prepare-shutdown controller reason)
+    (when (and active-p prepared-p)
+      (handler-case
+          (application-input-controller--interrupt-main-for-turn-cancellation
+           controller)
+        (error ()
+          nil))))
   nil)
+
+(-> application-input-controller--turn-cancellation-active-p
+    (application-input-controller)
+    boolean)
+(defun application-input-controller--turn-cancellation-active-p (controller)
+  "Return true while CONTROLLER is still finishing active-turn cancellation."
+  (not
+   (null
+    (with-lock-held ((application-input-controller-lock controller))
+      (application-input-controller-turn-cancellation-p controller)))))
+
+(-> application-input-controller--request-active-turn-cancellation
+    (application-input-controller &key (:force-exit-window-p boolean))
+    boolean)
+(defun application-input-controller--request-active-turn-cancellation
+    (controller &key force-exit-window-p)
+  "Atomically request cancellation only for CONTROLLER's current active turn.
+
+When FORCE-EXIT-WINDOW-P is true, arm the repeated-Ctrl-C option before
+cancellation can finish and schedule the hint that explains it."
+  (let ((accepted-p nil)
+        (message
+          (and force-exit-window-p
+               (application-input-controller--forced-exit-message
+                controller ':turn-cancellation))))
+    (with-lock-held ((application-input-controller-lock controller))
+      (when (and (application-input-controller-active-p controller)
+                 (not (application-input-controller-stopping-p controller))
+                 (not
+                  (application-input-controller-turn-cancellation-p controller)))
+        (setf (application-input-controller-turn-cancellation-p controller) t
+              (application-input-controller-turn-cancellation-delivery-pending-p
+               controller)
+              t
+              accepted-p t)
+        (when force-exit-window-p
+          (let ((now
+                  (funcall
+                   (application-input-controller-interrupt-clock-function
+                    controller))))
+            (setf (application-input-controller-interrupt-deadline controller)
+                  (+ now *application-interrupt-exit-window-seconds*)
+                  (application-input-controller-interrupt-hint-time controller)
+                  (+ now *application-interrupt-hint-delay-seconds*)
+                  (application-input-controller-forced-exit-message controller)
+                  message)))))
+    (when accepted-p
+      (handler-case
+          (application-input-controller--interrupt-main-for-turn-cancellation
+           controller)
+        (error ()
+          nil)))
+    accepted-p))
+
+(-> application-input-controller--active-turn-interrupt-action
+    (application-input-controller)
+    (option keyword))
+(defun application-input-controller--active-turn-interrupt-action (controller)
+  "Return and apply CONTROLLER's active-cancellation Ctrl-C action, if any.
+
+The forced-exit notice is prepared outside the lock because a lapsed press
+re-arms a window that a wedged turn may never let ordinary shutdown reach."
+  (let ((message
+          (application-input-controller--forced-exit-message
+           controller ':turn-cancellation)))
+    (with-lock-held ((application-input-controller-lock controller))
+      (when (application-input-controller-turn-cancellation-p controller)
+        (let* ((now
+                 (funcall
+                  (application-input-controller-interrupt-clock-function
+                   controller)))
+               (deadline
+                 (application-input-controller-interrupt-deadline controller)))
+          (if (and deadline (<= now deadline))
+              (progn
+                (setf (application-input-controller-interrupt-deadline controller)
+                      nil
+                      (application-input-controller-interrupt-hint-time controller)
+                      nil)
+                ':force)
+              (progn
+                ;; This press already outlived one window, so the wedged turn
+                ;; has earned its hint at the reader's next opportunity.
+                (setf (application-input-controller-interrupt-deadline controller)
+                      (+ now *application-interrupt-exit-window-seconds*)
+                      (application-input-controller-interrupt-hint-time controller)
+                      now
+                      (application-input-controller-forced-exit-message controller)
+                      message)
+                ':hint)))))))
 
 (-> application-input-controller--schedule-command
     (application-input-controller string)
@@ -495,24 +742,47 @@ Return true when a model or command turn still needs cancellation."
   "Apply terminal EVENT and publish any resulting work or exit request."
   (let ((ui (application-ui
              (application-input-controller-application controller)))
-        (turn-active-p
-          (application-input-controller-turn-active-p controller)))
-    (multiple-value-bind (action payload)
-        (terminal-ui-process-event
-         ui event :queue-completion-p turn-active-p)
-      (case action
-        (:submit
-         (application-input-controller--handle-submission
-          controller payload :steer-p turn-active-p))
-        (:queue
-         (application-input-controller--handle-queue-submission
-          controller payload))
-        (:edit-queue
-         (application-input-controller--recall-follow-up controller))
-        (:end-of-input
-         (application-input-controller--request-exit controller ':end-of-input))
-        (:interrupt
-         (application-input-controller--request-exit controller ':interrupt)))))
+        (active-interrupt-action
+          (and (eq event ':interrupt)
+               (application-input-controller--active-turn-interrupt-action
+                controller))))
+    (cond
+      ((eq active-interrupt-action ':force)
+       (application-input-controller--force-interrupt-exit controller))
+      ((eq active-interrupt-action ':hint)
+       nil)
+      ((and (eq event ':interrupt)
+            (application-input-controller--request-active-turn-cancellation
+             controller :force-exit-window-p t))
+       nil)
+      ((and (eq event ':escape)
+            (or
+             (application-input-controller--turn-cancellation-active-p
+              controller)
+             (application-input-controller--request-active-turn-cancellation
+              controller)))
+       nil)
+      (t
+       (let ((turn-active-p
+               (application-input-controller-turn-active-p controller)))
+         (multiple-value-bind (action payload)
+             (terminal-ui-process-event
+              ui event :queue-completion-p turn-active-p)
+           (case action
+             (:submit
+              (application-input-controller--handle-submission
+               controller payload :steer-p turn-active-p))
+             (:queue
+              (application-input-controller--handle-queue-submission
+               controller payload))
+             (:edit-queue
+              (application-input-controller--recall-follow-up controller))
+             (:end-of-input
+              (application-input-controller--request-exit
+               controller ':end-of-input))
+             (:interrupt
+              (application-input-controller--request-exit
+               controller ':interrupt))))))))
   nil)
 
 (-> application-input-controller--input-ready-p
@@ -550,6 +820,7 @@ Return true when a model or command turn still needs cancellation."
              (setf signal-backtrace (application-safe-backtrace)))))
       (handler-case
           (loop
+            (application-input-controller--refresh-interrupt-hint controller)
             (multiple-value-bind (stopping-p reader-paused-p)
                 (with-lock-held
                     ((application-input-controller-lock controller))
@@ -562,13 +833,16 @@ Return true when a model or command turn still needs cancellation."
                 (stopping-p
                  (let* ((application
                           (application-input-controller-application controller))
-                        (terminal
-                          (terminal-ui-terminal (application-ui application))))
+                        (ui (application-ui application))
+                        (terminal (terminal-ui-terminal ui)))
+                   (terminal-ui-refresh-status ui)
                    (if (terminal-input-ready-p terminal)
                        (case (terminal-read-event terminal)
                          (:interrupt
                           (application-input-controller--force-interrupt-exit
                            controller))
+                         (:escape
+                          nil)
                          (:end-of-input
                           (return)))
                        (with-lock-held
@@ -998,21 +1272,35 @@ Return true when a model or command turn still needs cancellation."
     null)
 (defun application-input-controller--finish-work (controller)
   "Finish current work and promote unconsumed steering before queued follow-ups."
-  (with-lock-held ((application-input-controller-lock controller))
-    (unless (application-input-controller-stopping-p controller)
-      (let ((steering-items
-              (application-input-controller-steering-items controller)))
-        (when steering-items
-          (setf (application-input-controller-work-items controller)
-                (append (mapcar (lambda (input)
-                                  (list ':message input))
-                                steering-items)
-                        (application-input-controller-work-items controller)))))
-      (setf (application-input-controller-steering-items controller) nil))
-    (setf (application-input-controller-active-p controller) nil)
-    (condition-notify
-     (application-input-controller-condition-variable controller)))
-  (application-input-controller--publish-counts controller)
+  (let ((clear-notice-p nil))
+    (with-lock-held ((application-input-controller-lock controller))
+      (unless (application-input-controller-stopping-p controller)
+        (let ((steering-items
+                (application-input-controller-steering-items controller)))
+          (when steering-items
+            (setf (application-input-controller-work-items controller)
+                  (append (mapcar (lambda (input)
+                                    (list ':message input))
+                                  steering-items)
+                          (application-input-controller-work-items controller)))))
+        (setf (application-input-controller-steering-items controller) nil))
+      (setf clear-notice-p
+            (or (application-input-controller-turn-cancellation-p controller)
+                (application-input-controller-interrupt-deadline controller))
+            (application-input-controller-active-p controller) nil
+            (application-input-controller-turn-cancellation-p controller) nil
+            (application-input-controller-turn-cancellation-delivery-pending-p
+             controller)
+            nil
+            (application-input-controller-interrupt-deadline controller) nil
+            (application-input-controller-interrupt-hint-time controller) nil)
+      (condition-notify
+       (application-input-controller-condition-variable controller)))
+    (when clear-notice-p
+      (terminal-ui-set-notice
+       (application-ui (application-input-controller-application controller))
+       nil))
+    (application-input-controller--publish-counts controller))
   nil)
 
 (-> application-input-controller-stop (application-input-controller) null)
@@ -1026,6 +1314,12 @@ Return true when a model or command turn still needs cancellation."
             (application-input-controller-steering-items controller) nil
             (application-input-controller-pending-later-entries controller) nil
             (application-input-controller-active-p controller) nil
+            (application-input-controller-turn-cancellation-p controller) nil
+            (application-input-controller-turn-cancellation-delivery-pending-p
+             controller)
+            nil
+            (application-input-controller-interrupt-deadline controller) nil
+            (application-input-controller-interrupt-hint-time controller) nil
             thread (application-input-controller-reader-thread controller))
       (condition-notify
        (application-input-controller-condition-variable controller)))
@@ -1100,6 +1394,10 @@ reader stays alive in interrupt-only mode until FUNCTION returns or unwinds."
              (setf signal-backtrace (application-safe-backtrace)))))
       (handler-case
           (application-handle-input application input)
+        (application-turn-cancelled (condition)
+          (error condition))
+        (application-input-failed (condition)
+          (error condition))
         (rollback-requested (condition)
           (error condition))
         ((or agent-loop-error

--- a/src/stream-terminal.lisp
+++ b/src/stream-terminal.lisp
@@ -41,8 +41,7 @@
 (-> terminal--enable-input-protocols (stream-terminal) null)
 (defun terminal--enable-input-protocols (terminal)
   "Enable distinguishable modified keys and bracketed paste on TERMINAL."
-  (enable-keyboard-enhancement
-   :stream (stream-terminal-output-stream terminal))
+  (terminal--write terminal (terminal-modified-keys-enable-sequence))
   (terminal--write terminal (terminal-bracketed-paste-enable-sequence))
   (terminal-flush terminal)
   nil)
@@ -51,8 +50,7 @@
 (defun terminal--disable-input-protocols (terminal)
   "Restore ordinary keyboard reporting and paste handling on TERMINAL."
   (terminal--write terminal (terminal-bracketed-paste-disable-sequence))
-  (disable-keyboard-enhancement
-   :stream (stream-terminal-output-stream terminal))
+  (terminal--write terminal (terminal-modified-keys-disable-sequence))
   (terminal-flush terminal)
   nil)
 

--- a/src/terminal-ui.lisp
+++ b/src/terminal-ui.lisp
@@ -128,6 +128,24 @@
        (with-recursive-lock-held ((terminal-ui-lock ,locked-ui))
          ,@body))))
 
+(-> terminal-ui--call-with-lock-if-available
+    (terminal-ui function)
+    (values t boolean))
+(defun terminal-ui--call-with-lock-if-available (ui function)
+  "Call FUNCTION under UI's lock when it is immediately available.
+
+The second value reports whether FUNCTION ran. This nonblocking path keeps
+emergency terminal input responsive while another thread owns presentation."
+  (let* ((lock (terminal-ui-lock ui))
+         (acquired-p
+           (sb-sys:without-interrupts
+             (sb-thread:grab-mutex lock :waitp nil))))
+    (if acquired-p
+        (unwind-protect
+             (values (funcall function) t)
+          (sb-thread:release-mutex lock))
+        (values nil nil))))
+
 
 ;;;; -- Terminal Presentation --
 
@@ -950,6 +968,14 @@ content; a narrow row drops it before any activity detail."
                      nil
                      (terminal-ui--status-row-at
                       ui status-now row-width)))))
+    (when (terminal-ui-notice ui)
+      (setf rows
+            (append rows
+                    (list
+                     nil
+                     (terminal--clip-spans
+                      (list (terminal-span ':hint (terminal-ui-notice ui)))
+                      row-width)))))
     (let ((steering-inputs (terminal-ui-steering-input-previews ui)))
       (when steering-inputs
         (setf rows
@@ -1066,6 +1092,18 @@ live unfinished line continuing that block, or removes it when NIL."
         (terminal-flush terminal))))
   ui)
 
+(-> terminal-ui--expire-notice-at (terminal-ui (option real)) boolean)
+(defun terminal-ui--expire-notice-at (ui now)
+  "Clear UI's notice when monotonic NOW reaches its deadline."
+  (if (and now
+           (terminal-ui-notice ui)
+           (>= now (terminal-ui-notice-deadline ui)))
+      (progn
+        (setf (terminal-ui-notice ui) nil
+              (terminal-ui-notice-deadline ui) nil)
+        t)
+      nil))
+
 (-> terminal-ui--present-live
     (terminal-ui &key (:status-now (option real))
                       (:appended-text string)
@@ -1076,9 +1114,11 @@ live unfinished line continuing that block, or removes it when NIL."
   "Present UI live content, atomically preceding it with appended scrollback."
   (let* ((status-now (or status-now
                          (and (or (terminal-ui-status ui)
-                                  (terminal-ui-agent-activities ui))
+                                  (terminal-ui-agent-activities ui)
+                                  (terminal-ui-notice ui))
                               (funcall (terminal-ui-clock-function ui)))))
          (terminal (terminal-ui-terminal ui)))
+    (terminal-ui--expire-notice-at ui status-now)
     (setf (terminal-ui-status-rendered-signature ui)
           (and status-now
                (terminal-ui--animation-signature-at ui status-now)))
@@ -1270,7 +1310,9 @@ when no resize needs to be applied."
     (unwind-protect
          (when (terminal-ui-started-p ui)
            (live-region-dismiss (terminal-ui-live-region ui)))
-      (setf (terminal-ui-started-p ui) nil)
+      (setf (terminal-ui-started-p ui) nil
+            (terminal-ui-notice ui) nil
+            (terminal-ui-notice-deadline ui) nil)
       (terminal-stop (terminal-ui-terminal ui))))
   ui)
 
@@ -1380,6 +1422,44 @@ when no resize needs to be applied."
       (terminal-ui--paint-live ui)))
   ui)
 
+(-> terminal-ui-set-notice
+    (terminal-ui (option string) &key (:duration-seconds (option real)))
+    (values terminal-ui boolean))
+(defun terminal-ui-set-notice (ui notice &key duration-seconds)
+  "Show NOTICE transiently for DURATION-SECONDS when UI is immediately available.
+
+A contended presentation lock drops the notice rather than delaying emergency
+terminal input or displaying a lifetime longer than the force-exit window. The
+second value reports whether UI applied this update, so a caller that must be
+seen can offer the notice again."
+  (let ((safe-notice (and notice
+                          (sanitize-text notice :single-line-p t)))
+        (applied-p nil))
+    (when (and safe-notice
+               (or (null duration-seconds)
+                   (not (plusp duration-seconds))))
+      (error 'terminal-error
+             :message "A terminal notice requires a positive duration."
+             :operation ':set-notice
+             :cause nil))
+    (setf applied-p
+          (nth-value
+           1
+           (terminal-ui--call-with-lock-if-available
+            ui
+            (lambda ()
+              (cond
+                (safe-notice
+                 (let ((now (funcall (terminal-ui-clock-function ui))))
+                   (setf (terminal-ui-notice ui) safe-notice
+                         (terminal-ui-notice-deadline ui) (+ now duration-seconds))
+                   (terminal-ui--paint-live ui now)))
+                ((terminal-ui-notice ui)
+                 (setf (terminal-ui-notice ui) nil
+                       (terminal-ui-notice-deadline ui) nil)
+                 (terminal-ui--paint-live ui)))))))
+    (values ui applied-p)))
+
 (-> terminal-ui-set-status
     (terminal-ui (option string)
      &key (:details terminal-styled-text)
@@ -1466,19 +1546,30 @@ frames, so this function never paints directly from a child thread."
 
 (-> terminal-ui-refresh-status (terminal-ui) boolean)
 (defun terminal-ui-refresh-status (ui)
-  "Repaint UI when a visible status or child-agent value changed."
-  (with-terminal-ui-locked (ui)
-    (let* ((status-now (and (or (terminal-ui-status ui)
-                                (terminal-ui-agent-activities ui))
-                            (funcall (terminal-ui-clock-function ui))))
-           (signature (and status-now
-                           (terminal-ui--animation-signature-at
-                            ui status-now))))
-      (if (equal signature (terminal-ui-status-rendered-signature ui))
-          nil
-          (progn
-            (terminal-ui--paint-live ui status-now)
-            t)))))
+  "Repaint changed live timing without waiting for a contended presentation lock."
+  (multiple-value-bind (repainted-p acquired-p)
+      (terminal-ui--call-with-lock-if-available
+       ui
+       (lambda ()
+         (let* ((status-now
+                  (and (or (terminal-ui-status ui)
+                           (terminal-ui-agent-activities ui)
+                           (terminal-ui-notice ui))
+                       (funcall (terminal-ui-clock-function ui))))
+                (notice-expired-p
+                  (terminal-ui--expire-notice-at ui status-now))
+                (signature nil))
+           (setf signature
+                 (and status-now
+                      (terminal-ui--animation-signature-at ui status-now)))
+           (if (and (not notice-expired-p)
+                    (equal signature
+                           (terminal-ui-status-rendered-signature ui)))
+               nil
+               (progn
+                 (terminal-ui--paint-live ui status-now)
+                 t)))))
+    (and acquired-p (not (null repainted-p)))))
 
 (-> terminal-ui-set-pending-inputs (terminal-ui list list) terminal-ui)
 (defun terminal-ui-set-pending-inputs (ui steering-inputs queued-inputs)

--- a/src/terminal.lisp
+++ b/src/terminal.lisp
@@ -27,6 +27,21 @@
   "Return the trusted control that disables bracketed paste mode."
   (format nil "~C[?2004l" *terminal-escape-character*))
 
+(-> terminal-modified-keys-enable-sequence () string)
+(defun terminal-modified-keys-enable-sequence ()
+  "Return xterm controls enabling distinguishable modified key reports.
+
+Autolith deliberately avoids Kitty keyboard disambiguation because its enhanced
+plain Escape report is not portable across the supported input decoder."
+  (format nil "~C[>4;0m~C[>4;2m"
+          *terminal-escape-character*
+          *terminal-escape-character*))
+
+(-> terminal-modified-keys-disable-sequence () string)
+(defun terminal-modified-keys-disable-sequence ()
+  "Return the xterm control restoring ordinary modified key reports."
+  (format nil "~C[>4;0m" *terminal-escape-character*))
+
 
 ;;;; -- Terminal Objects --
 
@@ -165,6 +180,16 @@
     :accessor terminal-ui-status
     :type (option string)
     :documentation "The optional unfinished activity shown above the prompt.")
+   (notice
+    :initform nil
+    :accessor terminal-ui-notice
+    :type (option string)
+    :documentation "The optional transient notice shown above the prompt.")
+   (notice-deadline
+    :initform nil
+    :accessor terminal-ui-notice-deadline
+    :type (option real)
+    :documentation "The monotonic time at which the transient notice expires.")
    (status-details
     :initform nil
     :accessor terminal-ui-status-details

--- a/tests/application-tests.lisp
+++ b/tests/application-tests.lisp
@@ -103,6 +103,115 @@
     (condition-notify (gated-provider-condition-variable provider)))
   nil)
 
+;;;; -- Active-Turn Cancellation Test Support --
+
+(defclass application-test-gated-tool (tool)
+  ((lock
+    :initform (make-lock "Autolith gated tool")
+    :reader application-test-gated-tool-lock
+    :type t
+    :documentation "The lock protecting deterministic tool execution timing.")
+   (condition-variable
+    :initform (make-condition-variable :name "Autolith gated tool")
+    :reader application-test-gated-tool-condition-variable
+    :type t
+    :documentation "The wait point for gated tool execution.")
+   (entered-p
+    :initform nil
+    :accessor application-test-gated-tool-entered-p
+    :type boolean
+    :documentation "Whether the tool reached its cancellable execution point.")
+   (released-p
+    :initform nil
+    :accessor application-test-gated-tool-released-p
+    :type boolean
+    :documentation "Whether a fallback cleanup may complete the tool.")
+   (completed-p
+    :initform nil
+    :accessor application-test-gated-tool--completed-p
+    :type boolean
+    :documentation "Whether the tool reached its normal completion point."))
+  (:documentation "A deterministic tool that waits until cancelled or released."))
+
+(-> application-test-gated-tool-wait-until-entered
+    (application-test-gated-tool real)
+    boolean)
+(defun application-test-gated-tool-wait-until-entered (tool timeout)
+  "Wait up to TIMEOUT for TOOL execution to reach its cancellation gate."
+  (task-tests--wait-until
+   (lambda ()
+     (with-lock-held ((application-test-gated-tool-lock tool))
+       (application-test-gated-tool-entered-p tool)))
+   timeout))
+
+(-> application-test-gated-tool-release (application-test-gated-tool) null)
+(defun application-test-gated-tool-release (tool)
+  "Allow TOOL to complete when test cleanup needs to release its gate."
+  (with-lock-held ((application-test-gated-tool-lock tool))
+    (setf (application-test-gated-tool-released-p tool) t)
+    (condition-notify (application-test-gated-tool-condition-variable tool)))
+  nil)
+
+(-> application-test-gated-tool-completed-p (application-test-gated-tool) boolean)
+(defun application-test-gated-tool-completed-p (tool)
+  "Return whether TOOL reached normal completion."
+  (not
+   (null
+    (with-lock-held ((application-test-gated-tool-lock tool))
+      (application-test-gated-tool--completed-p tool)))))
+
+(defmethod tool-execute ((tool application-test-gated-tool)
+                         (context tool-context)
+                         (arguments hash-table))
+  "Wait at TOOL's gate, then report completion only after explicit release."
+  (declare (ignore context arguments))
+  (with-lock-held ((application-test-gated-tool-lock tool))
+    (setf (application-test-gated-tool-entered-p tool) t)
+    (condition-notify (application-test-gated-tool-condition-variable tool))
+    (loop until (application-test-gated-tool-released-p tool)
+          do (condition-wait
+              (application-test-gated-tool-condition-variable tool)
+              (application-test-gated-tool-lock tool)))
+    (setf (application-test-gated-tool--completed-p tool) t))
+  (tool-success "gated tool completed"))
+
+(defclass application-test-counting-provider (scripted-provider)
+  ((lock
+    :initform (make-lock "Autolith counting provider")
+    :reader application-test-counting-provider-lock
+    :type t
+    :documentation "The lock protecting the completed request count.")
+   (request-count
+    :initform 0
+    :accessor application-test-counting-provider-request-count
+    :type (integer 0)
+    :documentation "The number of provider requests that returned a result."))
+  (:documentation "A scripted provider exposing a synchronized request count."))
+
+(defmethod provider-stream-turn :around
+    ((provider application-test-counting-provider)
+     (conversation conversation)
+     &key tool-namespaces event-callback goal-context compaction-p)
+  "Count PROVIDER requests only after their scripted result is available."
+  (declare (ignore conversation tool-namespaces event-callback
+                   goal-context compaction-p))
+  (let ((result (call-next-method)))
+    (with-lock-held ((application-test-counting-provider-lock provider))
+      (incf (application-test-counting-provider-request-count provider)))
+    result))
+
+(-> application-test-counting-provider-wait-for-requests
+    (application-test-counting-provider (integer 0) real)
+    boolean)
+(defun application-test-counting-provider-wait-for-requests
+    (provider count timeout)
+  "Wait up to TIMEOUT for PROVIDER to return at least COUNT scripted results."
+  (task-tests--wait-until
+   (lambda ()
+     (with-lock-held ((application-test-counting-provider-lock provider))
+       (>= (application-test-counting-provider-request-count provider) count)))
+   timeout))
+
 (defclass responsive-scripted-terminal (scripted-terminal)
   ((provider
     :initarg :provider
@@ -805,116 +914,105 @@
 
 (-> test-repeated-interrupt-forces-exit () null)
 (defun test-repeated-interrupt-forces-exit ()
-  "Test another Ctrl-C bypasses APPLICATION-RUN's blocked runtime cleanup."
+  "Test a second active-cancellation Ctrl-C forces exit before cleanup finishes."
   (let* ((configuration (test-configuration))
          (root (test-configuration-root configuration))
          (conversation (conversation-create configuration
-                                            :identifier "force-resume"))
-         (terminal (make-instance 'queued-recording-terminal :columns 80))
-         (ui (terminal-ui-create :terminal terminal))
-         (registry (make-instance 'tool-registry))
-         (application
-           (make-instance 'application
-                          :configuration configuration
-                          :conversation conversation
-                          :provider nil
-                          :tool-registry registry
-                          :worker nil
-                          :agent nil
-                          :ui ui))
-         (barrier-lock (make-lock "Autolith shutdown cleanup test"))
-         (barrier (make-condition-variable
-                   :name "Autolith shutdown cleanup test"))
-         (cleanup-entered-p nil)
-         (cleanup-released-p nil)
-         (cleanup-timed-out-p nil)
-         (forced-status nil)
-         (terminal-restored-before-exit-p nil)
-         (first-exit-reason nil)
-         (reader-alive-during-cleanup-p nil)
-         (producer nil))
+                                            :identifier "force-resume")))
     (unwind-protect
-         (progn
-           (conversation-append-user-message conversation "preserve this work")
-           (tool-registry-register
-            registry
-            (make-instance
-             'tool-test-runtime-tool
-             :namespace "test"
-             :name "shutdown"
-             :description "Wait at the shutdown regression barrier."
-             :parameters (json-object "type" "object")
-             :runtime-identity (list ':shutdown-barrier)
-             :close-function
-             (lambda ()
-               ;; Holding the presentation lock proves the emergency path
-               ;; never waits for repaint or ordinary UI serialization.
-               (with-terminal-ui-locked (ui)
-                 (with-lock-held (barrier-lock)
-                   (let ((controller
-                           (application-input-controller application)))
-                     (setf first-exit-reason
-                           (application-input-controller-exit-reason controller)
-                           reader-alive-during-cleanup-p
-                           (thread-alive-p
-                            (application-input-controller-reader-thread
-                             controller))))
-                   (setf cleanup-entered-p t)
-                   (condition-notify barrier)
-                   (unless cleanup-released-p
-                     (condition-wait barrier barrier-lock :timeout 2))
-                   (setf cleanup-timed-out-p
-                         (not cleanup-released-p)))))
-             :detach-function (lambda () nil)))
-           (queued-recording-terminal-enqueue terminal ':interrupt)
-           (setf producer
-                 (make-thread
-                  (lambda ()
-                    (with-lock-held (barrier-lock)
-                      (unless cleanup-entered-p
-                        (condition-wait barrier barrier-lock :timeout 2)))
-                    (queued-recording-terminal-enqueue terminal ':interrupt))
-                  :name "Autolith repeated Ctrl-C test"))
-           (let ((*application-forced-exit-function*
+         (let* ((terminal (make-instance 'recording-terminal :columns 80))
+                (ui (terminal-ui-create :terminal terminal))
+                (application (make-instance 'application
+                                            :configuration configuration
+                                            :conversation conversation
+                                            :ui ui))
+                (forced-status nil)
+                (terminal-restored-before-exit-p nil)
+                (controller
+                  (make-instance
+                   'application-input-controller
+                   :application application
+                   :later-state (make-instance 'later-state)
+                   :pending-later-entries nil
+                   :main-thread (current-thread)
+                   :interrupt-clock-function (lambda () 10)
+                   :forced-exit-function
                    (lambda (status)
-                     (with-lock-held (barrier-lock)
-                       (setf forced-status status
-                             terminal-restored-before-exit-p
-                             (and (not (terminal-started-p terminal))
-                                  (not (terminal-interactive-p terminal)))
-                             cleanup-released-p t)
-                       (condition-notify barrier)))))
-             (application-run application))
-           (join-thread producer)
-           (setf producer nil)
-           (test-assert (eq first-exit-reason ':interrupt)
-                        "the first Ctrl-C remains a graceful interrupt")
-           (test-assert reader-alive-during-cleanup-p
-                        "the interrupt-only reader survives into runtime cleanup")
-           (test-assert (not cleanup-timed-out-p)
-                        "repeated Ctrl-C escapes blocked shutdown cleanup")
-           (test-assert (= forced-status *application-forced-interrupt-status*)
-                        "a repeated Ctrl-C forces process status 130")
-           (test-assert terminal-restored-before-exit-p
-                        "forced interruption restores the terminal before exit")
-           (let ((output (recording-terminal-output terminal)))
+                     (setf forced-status status
+                           terminal-restored-before-exit-p
+                           (and (not (terminal-started-p terminal))
+                                (not (terminal-interactive-p terminal))))))))
+           (conversation-append-user-message conversation "keep this conversation")
+           (setf (application-input-controller application) controller
+                 (application-input-controller-active-p controller) t)
+           (with-terminal-ui (active-ui ui)
+             (declare (ignore active-ui))
+             (application-input-controller--process-event controller ':interrupt)
              (test-assert
-              (search "Ctrl-C pressed again; forcing Autolith to exit." output)
-              "forced interruption explains why Autolith is exiting")
-             (test-assert (search "autolith resume force-resume" output)
-                          "forced interruption preserves the exact resume command")))
-      (when producer
-        (ignore-errors (join-thread producer)))
-      (ignore-errors (terminal-ui-stop ui))
-      (uiop:delete-directory-tree root
-                                  :validate t
-                                  :if-does-not-exist :ignore)))
+              (application-input-controller-turn-cancellation-p controller)
+              "the first Ctrl-C leaves cancellation cleanup pending")
+             (test-assert (null forced-status)
+                          "the first active Ctrl-C never forces exit")
+             (application-input-controller--process-event controller ':interrupt)
+             (test-assert (= forced-status *application-forced-interrupt-status*)
+                          "a timely second active Ctrl-C forces process status 130")
+             (test-assert terminal-restored-before-exit-p
+                          "forced interruption restores the terminal before exit")
+             (test-assert
+              (null (application-input-controller-exit-reason controller))
+              "active cancellation does not become application shutdown")
+             (let ((output (recording-terminal-output terminal)))
+               (test-assert
+                (search
+                 "Ctrl-C pressed twice within 2.5 seconds; forcing Autolith to exit."
+                 output)
+                "forced interruption explains the active cancellation window")
+               (test-assert
+                (search "autolith resume force-resume" output)
+                "forced cancellation carries the exact resume command"))))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist :ignore)))
+  nil)
+
+(-> test-forced-exit-without-durable-conversation () null)
+(defun test-forced-exit-without-durable-conversation ()
+  "Test forced exit offers no resume command for an unsaved conversation."
+  (let* ((terminal (make-instance 'recording-terminal :columns 80))
+         (ui (terminal-ui-create :terminal terminal))
+         (application (make-instance 'application :ui ui))
+         (forced-status nil)
+         (controller
+           (make-instance
+            'application-input-controller
+            :application application
+            :later-state (make-instance 'later-state)
+            :pending-later-entries nil
+            :main-thread (current-thread)
+            :interrupt-clock-function (lambda () 10)
+            :forced-exit-function
+            (lambda (status)
+              (setf forced-status status)))))
+    (setf (application-input-controller application) controller
+          (application-input-controller-active-p controller) t)
+    (with-terminal-ui (active-ui ui)
+      (declare (ignore active-ui))
+      (application-input-controller--process-event controller ':interrupt)
+      (application-input-controller--process-event controller ':interrupt)
+      (test-assert (= forced-status *application-forced-interrupt-status*)
+                   "a timely second active Ctrl-C still forces exit")
+      (let ((output (recording-terminal-output terminal)))
+        (test-assert
+         (search
+          "Ctrl-C pressed twice within 2.5 seconds; forcing Autolith to exit."
+          output)
+         "forced interruption still explains why Autolith exits")
+        (test-assert (not (search "autolith resume" output))
+                     "an unsaved conversation produces no resume command"))))
   nil)
 
 (-> test-graceful-shutdown-retains-interrupt-escape () null)
 (defun test-graceful-shutdown-retains-interrupt-escape ()
-  "Test every graceful shutdown reason retains the emergency Ctrl-C reader."
-  (dolist (reason '(:quit :end-of-input))
+  "Test Ctrl-C forces already-pending shutdown while Escape remains harmless."
+  (dolist (reason '(:quit :end-of-input :shutdown))
     (let* ((terminal (make-instance 'queued-recording-terminal :columns 80))
            (ui (terminal-ui-create :terminal terminal))
            (application (make-instance 'application :ui ui))
@@ -935,6 +1033,16 @@
               (thread-alive-p
                (application-input-controller-reader-thread controller))
               "graceful shutdown preserves its interrupt-only reader")
+             (test-assert
+              (null (application-input-controller-interrupt-deadline controller))
+              "ordinary shutdown never owns the active-cancellation timer")
+             (test-assert (null (terminal-ui-notice ui))
+                          "ordinary shutdown never shows the force-window hint")
+             (queued-recording-terminal-enqueue terminal ':escape)
+             (sleep 0.05)
+             (test-assert
+              (null (with-lock-held (status-lock) forced-status))
+              "Escape remains harmless during graceful shutdown")
              (queued-recording-terminal-enqueue terminal ':interrupt)
              (test-assert
               (task-tests--wait-until
@@ -943,16 +1051,762 @@
                    (= (or forced-status -1)
                       *application-forced-interrupt-status*)))
                2)
-              "Ctrl-C forces exit while non-interrupt shutdown is pending")
+              "Ctrl-C immediately forces already-pending shutdown")
              (application-input-controller-stop controller)
              (setf controller nil)
              (test-assert
-              (search "Ctrl-C pressed during shutdown; forcing Autolith to exit."
-                      (recording-terminal-output terminal))
-              "forced exit distinguishes an interrupt during graceful shutdown"))
+              (search
+               "Ctrl-C pressed during shutdown; forcing Autolith to exit."
+               (recording-terminal-output terminal))
+              "forced shutdown explains that cleanup was already pending"))
         (when controller
           (ignore-errors (application-input-controller-stop controller)))
         (ignore-errors (terminal-ui-stop ui)))))
+  nil)
+
+(-> test-active-turn-interrupt-events () null)
+(defun test-active-turn-interrupt-events ()
+  "Test Ctrl-C and Escape request turn-only cancellation without data loss."
+  (dolist (event '(:interrupt :escape))
+    (let* ((now 10)
+           (terminal (make-instance 'recording-terminal :columns 80))
+           (ui (terminal-ui-create
+                :terminal terminal
+                :clock-function (lambda () now)))
+           (application (make-instance 'application :ui ui))
+           (controller
+             (make-instance
+              'application-input-controller
+              :application application
+              :later-state (make-instance 'later-state)
+              :pending-later-entries nil
+              :main-thread (current-thread)
+              :interrupt-clock-function (lambda () now))))
+      (setf (application-input-controller application) controller
+            (application-input-controller-active-p controller) t
+            (application-input-controller-work-items controller)
+            (list (list ':message "queued"))
+            (application-input-controller-steering-items controller)
+            (list "steering"))
+      (terminal-ui-set-input ui "draft survives")
+      (application-input-controller--process-event controller event)
+      (test-assert (not (application-input-controller-stopping-p controller))
+                   "an active-turn stop keeps the application running")
+      (test-assert (null (application-input-controller-exit-reason controller))
+                   "an active-turn stop does not set an application exit reason")
+      (test-assert
+       (string= (line-editor-text (terminal-ui-editor ui)) "draft survives")
+       "active-turn stop keys preserve the current draft")
+      (test-assert
+       (equal (application-input-controller-work-items controller)
+              (list (list ':message "queued")))
+       "active-turn stop keys preserve queued work")
+      (test-assert
+       (equal (application-input-controller-steering-items controller)
+              (list "steering"))
+       "active-turn stop keys preserve steering work")
+      (test-assert
+       (application-input-controller-turn-cancellation-p controller)
+       "the cancellation lifecycle remains active until work cleanup finishes")
+      (test-assert
+       (eq (not (null
+                 (application-input-controller-interrupt-deadline controller)))
+           (eq event ':interrupt))
+       "only active Ctrl-C arms the force-exit window")
+      (test-assert
+       (eq (not (null
+                 (application-input-controller-interrupt-hint-time controller)))
+           (eq event ':interrupt))
+       "only active Ctrl-C schedules the transient force-exit notice")
+      (test-assert (null (terminal-ui-notice ui))
+                   "no stop key shows the force-exit notice immediately")
+      (application-input-controller--refresh-interrupt-hint controller)
+      (test-assert (null (terminal-ui-notice ui))
+                   "a cancellation inside the hint delay stays silent")
+      (setf now 21/2)
+      (application-input-controller--refresh-interrupt-hint controller)
+      (test-assert
+       (eq (not (null (terminal-ui-notice ui)))
+           (eq event ':interrupt))
+       "only active Ctrl-C announces forced exit once cancellation persists")
+      (test-assert
+       (or (eq event ':escape)
+           (= (terminal-ui-notice-deadline ui)
+              (application-input-controller-interrupt-deadline controller)))
+       "the visible notice expires exactly with the force-exit window")
+      (test-assert
+       (application-input-controller--consume-turn-cancellation-delivery-p
+        controller)
+       "the first active stop records one pending cancellation delivery")
+      (test-assert
+       (not
+        (application-input-controller--request-active-turn-cancellation
+         controller))
+       "turn-only cancellation has a single request winner")
+      (test-assert
+       (not
+        (application-input-controller--consume-turn-cancellation-delivery-p
+         controller))
+       "a repeated request does not re-arm cancellation delivery")
+      (application-input-controller--finish-work controller)
+      (test-assert
+       (and (not (application-input-controller-turn-cancellation-p controller))
+            (null
+             (application-input-controller-interrupt-deadline controller))
+            (null (terminal-ui-notice ui)))
+       "work cleanup ends the cancellation lifecycle and force window")))
+  nil)
+
+(-> test-idle-interrupt-exits-without-force-hint () null)
+(defun test-idle-interrupt-exits-without-force-hint ()
+  "Test idle Ctrl-C clears a draft or exits directly without force state."
+  (let* ((terminal (make-instance 'recording-terminal :columns 80))
+         (ui (terminal-ui-create :terminal terminal))
+         (application (make-instance 'application :ui ui))
+         (controller
+           (make-instance
+            'application-input-controller
+            :application application
+            :later-state (make-instance 'later-state)
+            :pending-later-entries nil
+            :main-thread (current-thread)
+            :interrupt-clock-function (lambda () 10))))
+    (setf (application-input-controller application) controller)
+    (terminal-ui-set-input ui "clear me")
+    (application-input-controller--process-event controller ':interrupt)
+    (test-assert (not (application-input-controller-stopping-p controller))
+                 "idle Ctrl-C only clears a nonempty draft")
+    (test-assert (string= (line-editor-text (terminal-ui-editor ui)) "")
+                 "idle Ctrl-C clears the current draft")
+    (test-assert
+     (and (null (application-input-controller-interrupt-deadline controller))
+          (null (terminal-ui-notice ui)))
+     "clearing an idle draft never arms or displays forced exit")
+    (application-input-controller--process-event controller ':interrupt)
+    (test-assert (application-input-controller-stopping-p controller)
+                 "idle Ctrl-C at an empty prompt requests graceful exit")
+    (test-assert (eq (application-input-controller-exit-reason controller)
+                     ':interrupt)
+                 "empty-prompt Ctrl-C preserves the interrupt exit reason")
+    (test-assert
+     (and (null (application-input-controller-interrupt-deadline controller))
+          (null (terminal-ui-notice ui)))
+     "empty-prompt Ctrl-C exits without a force window or hint"))
+  nil)
+
+(-> test-active-turn-stop-keys () null)
+(defun test-active-turn-stop-keys ()
+  "Test Ctrl-C and Escape cancel one provider turn and return to the prompt."
+  (let* ((configuration (test-configuration))
+         (root (test-configuration-root configuration)))
+    (unwind-protect
+         (dolist (event '(:interrupt :escape))
+           (let* ((conversation
+                    (conversation-create
+                     configuration
+                     :identifier (format nil "active-stop-~(~A~)" event)))
+                  (provider
+                    (make-instance
+                     'gated-provider
+                     :results
+                     (list
+                      (agent-test-result
+                       "unexpected completion"
+                       (list (agent-test-message "not cancelled"))
+                       :turn-completion :end))))
+                  (terminal
+                    (make-instance 'queued-recording-terminal :columns 80))
+                  (ui (terminal-ui-create :terminal terminal))
+                  (registry (agent-test-registry))
+                  (agent (agent-create :configuration configuration
+                                       :provider provider
+                                       :conversation conversation
+                                       :tool-registry registry
+                                       :worker nil))
+                  (application
+                    (make-instance 'application
+                                   :configuration configuration
+                                   :conversation conversation
+                                   :provider provider
+                                   :tool-registry registry
+                                   :worker nil
+                                   :agent agent
+                                   :ui ui))
+                  (forced-status nil)
+                  (provider-entered-observed-p nil)
+                  (cancellation-finished-observed-p nil)
+                  (draft-preserved-observed-p nil)
+                  (output-before-exit nil)
+                  (producer nil))
+             (queued-recording-terminal-enqueue
+              terminal '(:insert "cancel this turn"))
+             (queued-recording-terminal-enqueue terminal ':submit)
+             (setf producer
+                   (make-thread
+                    (lambda ()
+                      (setf provider-entered-observed-p
+                            (task-tests--wait-until
+                             (lambda ()
+                               (gated-provider-entered-p provider))
+                             2))
+                      (when provider-entered-observed-p
+                        (queued-recording-terminal-enqueue
+                         terminal '(:insert "draft survives"))
+                        (queued-recording-terminal-enqueue terminal event)
+                        (setf cancellation-finished-observed-p
+                              (task-tests--wait-until
+                               (lambda ()
+                                 (let ((controller
+                                         (application-input-controller
+                                          application)))
+                                   (and controller
+                                        (not
+                                         (application-input-controller-turn-active-p
+                                          controller))
+                                        (not
+                                         (application-input-controller--turn-cancellation-active-p
+                                          controller))
+                                        (null
+                                         (application-input-controller-interrupt-deadline
+                                          controller))
+                                        (null (terminal-ui-notice ui)))))
+                               2)))
+                      (unless cancellation-finished-observed-p
+                        (gated-provider-release provider)
+                        (task-tests--wait-until
+                         (lambda ()
+                           (let ((controller
+                                   (application-input-controller application)))
+                             (and controller
+                                  (not
+                                   (application-input-controller-turn-active-p
+                                    controller)))))
+                         2))
+                      (setf draft-preserved-observed-p
+                            (string=
+                             (line-editor-text (terminal-ui-editor ui))
+                             "draft survives")
+                            output-before-exit
+                            (recording-terminal-output terminal))
+                      (queued-recording-terminal-enqueue terminal ':interrupt)
+                      (queued-recording-terminal-enqueue
+                       terminal '(:insert "/quit"))
+                      (queued-recording-terminal-enqueue terminal ':submit))
+                    :name "Autolith active-turn stop-key test"))
+             (unwind-protect
+                  (let ((*application-forced-exit-function*
+                          (lambda (status)
+                            (setf forced-status status))))
+                    (application-run application))
+               (gated-provider-release provider)
+               (when producer
+                 (join-thread producer)
+                 (setf producer nil)))
+             (test-assert provider-entered-observed-p
+                          "the provider turn reaches its cancellation gate")
+             (test-assert cancellation-finished-observed-p
+                          "the cancelled turn finishes and returns to input")
+             (test-assert
+              (not (search "not cancelled"
+                           (recording-terminal-output terminal)))
+              "the stop key cancels the active provider turn")
+             (test-assert (null forced-status)
+                          "one active-turn stop key never forces exit")
+             (test-assert draft-preserved-observed-p
+                          "the active reader preserves draft text while cancelling")
+             (test-assert
+              (not
+               (search "To resume this conversation, run:" output-before-exit))
+              "active-turn cancellation never prints a resume command")
+             (test-assert
+              (not
+               (search "Press Ctrl-C again within 2.5 seconds"
+                       output-before-exit))
+              "a promptly cancelled turn never flashes the force-exit hint")))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist :ignore)))
+  nil)
+
+;;;; -- Active Command Cancellation --
+
+(-> test-active-command-stop-key () null)
+(defun test-active-command-stop-key ()
+  "Test Escape cancels a shared active command without fatal recovery."
+  (let* ((configuration (test-configuration))
+         (root          (test-configuration-root configuration))
+         (conversation  (conversation-create configuration
+                                            :identifier "active-command-stop"))
+         (terminal      (make-instance 'queued-recording-terminal :columns 80))
+         (ui            (terminal-ui-create :terminal terminal))
+         (application   (make-instance 'application
+                                       :configuration configuration
+                                       :conversation conversation
+                                       :provider nil
+                                       :tool-registry (make-instance 'tool-registry)
+                                       :worker nil
+                                       :agent nil
+                                       :ui ui))
+         (command-lock  (make-lock "Autolith active command stop-key test"))
+         (command-gate  (make-condition-variable
+                         :name "Autolith active command stop-key test"))
+         (command-entered-p nil)
+         (command-released-p nil)
+         (registrations (application-command--registry-snapshot))
+         (forced-status nil)
+         (cancellation-finished-observed-p nil)
+         (draft-preserved-observed-p nil)
+         (producer nil))
+    (unwind-protect
+         (unwind-protect
+              (progn
+                (register-application-command
+                 (application-command-create
+                  :definition-name 'test-active-command-stop-key-command
+                  :name "/test-cancel-command"
+                  :aliases nil
+                  :argument nil
+                  :description "Block until the active-turn cancellation test stops it."
+                  :tip "Use this test command only from the application test suite."
+                  :busy-behavior ':hold
+                  :terminal-behavior ':shared
+                  :handler
+                  (lambda (ignored-application ignored-invocation)
+                    (declare (ignore ignored-application ignored-invocation))
+                    (with-lock-held (command-lock)
+                      (setf command-entered-p t)
+                      (condition-notify command-gate)
+                      (loop until command-released-p
+                            do (condition-wait command-gate command-lock)))
+                    ':continue))
+                 :source ':test)
+                (queued-recording-terminal-enqueue
+                 terminal '(:insert "/test-cancel-command"))
+                (queued-recording-terminal-enqueue terminal ':submit)
+                (setf producer
+                      (make-thread
+                       (lambda ()
+                         (let ((command-entered-observed-p
+                                 (task-tests--wait-until
+                                  (lambda ()
+                                    (with-lock-held (command-lock)
+                                      command-entered-p))
+                                  2)))
+                           (when command-entered-observed-p
+                             (queued-recording-terminal-enqueue
+                              terminal '(:insert "draft survives"))
+                             (queued-recording-terminal-enqueue terminal ':escape)
+                             (setf cancellation-finished-observed-p
+                                   (task-tests--wait-until
+                                    (lambda ()
+                                      (let ((controller
+                                              (application-input-controller
+                                               application)))
+                                        (and controller
+                                             (not
+                                              (application-input-controller-turn-active-p
+                                               controller))
+                                             (not
+                                              (application-input-controller--turn-cancellation-active-p
+                                               controller)))))
+                                    2)))
+                           (unless cancellation-finished-observed-p
+                             (with-lock-held (command-lock)
+                               (setf command-released-p t)
+                               (condition-notify command-gate)))
+                           (setf draft-preserved-observed-p
+                                 (string=
+                                  (line-editor-text (terminal-ui-editor ui))
+                                  "draft survives"))
+                           (queued-recording-terminal-enqueue terminal ':interrupt)
+                           (queued-recording-terminal-enqueue terminal ':interrupt)))
+                       :name "Autolith active command stop-key test"))
+                (let ((*application-forced-exit-function*
+                        (lambda (status)
+                          (setf forced-status status))))
+                  (application-run application))
+                (test-assert cancellation-finished-observed-p
+                             "Escape cancels a shared active command and returns to input")
+                (test-assert draft-preserved-observed-p
+                             "command cancellation preserves the draft")
+                (test-assert (null forced-status)
+                             "command cancellation never enters forced exit"))
+           (with-lock-held (command-lock)
+             (setf command-released-p t)
+             (condition-notify command-gate))
+           (when producer
+             (join-thread producer)
+             (setf producer nil))
+           (application-command--registry-restore registrations))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist :ignore)))
+  nil)
+
+;;;; -- Active Tool Cancellation --
+
+(-> test-active-tool-stop-repairs-unknown-outcome () null)
+(defun test-active-tool-stop-repairs-unknown-outcome ()
+  "Test cancellation records an unknown tool outcome before the next turn."
+  (let* ((configuration (test-configuration))
+         (root          (test-configuration-root configuration)))
+    (unwind-protect
+         (let* ((conversation
+                  (conversation-create configuration :identifier "active-tool-stop"))
+                (provider
+                  (make-instance
+                   'application-test-counting-provider
+                   :results
+                   (list
+                    (agent-test-result
+                     "tool-call"
+                     (list
+                      (agent-test-call
+                       :call-id "interrupted-tool-call"
+                       :name "gate")))
+                    (agent-test-result
+                     "recovered-turn"
+                     (list (agent-test-message "the next turn ran"))
+                     :turn-completion :end))))
+                (registry (agent-test-registry))
+                (tool
+                  (make-instance
+                   'application-test-gated-tool
+                   :namespace "test"
+                   :name "gate"
+                   :description "Wait at the active-tool cancellation test gate."
+                   :parameters (tool-object-schema (json-object) '())))
+                (terminal (make-instance 'queued-recording-terminal :columns 80))
+                (ui (terminal-ui-create :terminal terminal))
+                (agent (agent-create :configuration configuration
+                                     :provider provider
+                                     :conversation conversation
+                                     :tool-registry registry
+                                     :worker nil))
+                (application
+                  (make-instance 'application
+                                 :configuration configuration
+                                 :conversation conversation
+                                 :provider provider
+                                 :tool-registry registry
+                                 :worker nil
+                                 :agent agent
+                                 :ui ui))
+                (forced-status nil)
+                (tool-entered-observed-p nil)
+                (cancellation-finished-observed-p nil)
+                (next-turn-observed-p nil)
+                (producer nil))
+           (tool-registry-register registry tool)
+           (queued-recording-terminal-enqueue
+            terminal '(:insert "run the gated tool"))
+           (queued-recording-terminal-enqueue terminal ':submit)
+           (setf producer
+                 (make-thread
+                  (lambda ()
+                    (setf tool-entered-observed-p
+                          (application-test-gated-tool-wait-until-entered tool 2))
+                    (when tool-entered-observed-p
+                      (queued-recording-terminal-enqueue terminal ':escape)
+                      (setf cancellation-finished-observed-p
+                            (task-tests--wait-until
+                             (lambda ()
+                               (let ((controller
+                                       (application-input-controller application)))
+                                 (and controller
+                                      (not
+                                       (application-input-controller-turn-active-p
+                                        controller))
+                                      (not
+                                       (application-input-controller--turn-cancellation-active-p
+                                        controller)))))
+                             2)))
+                    (unless cancellation-finished-observed-p
+                      (application-test-gated-tool-release tool))
+                    (when cancellation-finished-observed-p
+                      (queued-recording-terminal-enqueue
+                       terminal '(:insert "continue after cancellation"))
+                      (queued-recording-terminal-enqueue terminal ':submit)
+                      (setf next-turn-observed-p
+                            (application-test-counting-provider-wait-for-requests
+                             provider 2 2)))
+                    (queued-recording-terminal-enqueue terminal ':interrupt))
+                  :name "Autolith active tool stop-key test"))
+           (unwind-protect
+                (let ((*application-forced-exit-function*
+                        (lambda (status)
+                          (setf forced-status status))))
+                  (application-run application))
+             (application-test-gated-tool-release tool)
+             (when producer
+               (join-thread producer)
+               (setf producer nil)))
+           (test-assert tool-entered-observed-p
+                        "the tool reaches its cancellable execution point")
+           (test-assert cancellation-finished-observed-p
+                        "active-tool cancellation finishes before the next turn")
+           (test-assert next-turn-observed-p
+                        "the next queued message reaches the provider")
+           (test-assert (not (application-test-gated-tool-completed-p tool))
+                        "cancellation leaves the tool outcome unknown")
+           (test-assert (null forced-status)
+                        "one active-tool stop key never forces exit")
+           (let* ((snapshots
+                    (nreverse
+                     (copy-list
+                      (scripted-provider-input-snapshots provider))))
+                  (next-request (second snapshots))
+                  (output
+                    (find-if
+                     (lambda (item)
+                       (and (json-object-p item)
+                            (string=
+                             (or (json-get item "type") "")
+                             "function_call_output")))
+                     next-request)))
+             (test-assert (= (length snapshots) 2)
+                          "cancellation prevents a same-turn tool retry request")
+             (test-assert output
+                          "the next request includes an unknown-outcome tool result")
+             (test-assert
+              (string= (json-get output "call_id") "interrupted-tool-call")
+              "the repaired result retains its original tool call identifier")
+             (test-assert
+              (string= (json-get output "output")
+                       *conversation-interrupted-tool-output*)
+              "the repaired result explains that tool state is unknown")))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist :ignore)))
+  nil)
+
+(-> test-interrupt-force-window () null)
+(defun test-interrupt-force-window ()
+  "Test only a second Ctrl-C within 2.5 seconds requests forced exit."
+  (let* ((now 10)
+         (application (make-instance 'application))
+         (controller
+           (make-instance
+            'application-input-controller
+            :application application
+            :later-state (make-instance 'later-state)
+            :pending-later-entries nil
+            :main-thread (current-thread)
+            :interrupt-clock-function (lambda () now))))
+    (setf (application-input-controller application) controller
+          (application-input-controller-active-p controller) t)
+    (test-assert
+     (null
+      (application-input-controller--active-turn-interrupt-action controller))
+     "an idle Ctrl-C owns no active-cancellation action")
+    (test-assert
+     (application-input-controller--request-active-turn-cancellation
+      controller :force-exit-window-p t)
+     "the first Ctrl-C only arms forced exit")
+    (setf now 25/2)
+    (test-assert
+     (eq (application-input-controller--active-turn-interrupt-action controller)
+         ':force)
+     "a second Ctrl-C at the 2.5-second boundary forces exit")
+    (setf now 15)
+    (test-assert
+     (eq (application-input-controller--active-turn-interrupt-action controller)
+         ':hint)
+     "a later first Ctrl-C starts a fresh window")
+    (setf now 17501/1000)
+    (test-assert
+     (eq (application-input-controller--active-turn-interrupt-action controller)
+         ':hint)
+     "a Ctrl-C after 2.5 seconds does not force exit")
+    (setf now 20)
+    (test-assert
+     (eq (application-input-controller--active-turn-interrupt-action controller)
+         ':force)
+     "the press after an expired window can arm a new timely second press"))
+  nil)
+
+(-> test-visible-interrupt-hint-does-not-extend-window () null)
+(defun test-visible-interrupt-hint-does-not-extend-window ()
+  "Test a delayed visible notice cannot extend an expired force deadline."
+  (let* ((now 0)
+         (terminal (make-instance 'recording-terminal :columns 80))
+         (ui (terminal-ui-create
+              :terminal terminal
+              :clock-function (lambda () now)))
+         (application (make-instance 'application :ui ui))
+         (controller
+           (make-instance
+            'application-input-controller
+            :application application
+            :later-state (make-instance 'later-state)
+            :pending-later-entries nil
+            :main-thread (current-thread)
+            :interrupt-clock-function (lambda () now))))
+    (setf (application-input-controller application) controller
+          (application-input-controller-active-p controller) t)
+    (test-assert
+     (application-input-controller--request-active-turn-cancellation
+      controller :force-exit-window-p t)
+     "the first Ctrl-C arms the force-exit deadline")
+    (terminal-ui-set-notice
+     ui
+     "Press Ctrl-C again within 2.5 seconds to force exit."
+     :duration-seconds 5)
+    (setf now 3)
+    (test-assert
+     (eq (application-input-controller--active-turn-interrupt-action controller)
+         ':hint)
+     "a visible notice cannot make an expired Ctrl-C force exit")
+    (test-assert
+     (= (application-input-controller-interrupt-deadline controller) 11/2)
+     "the expired press starts a fresh 2.5-second window"))
+  nil)
+
+(-> test-dropped-interrupt-hint-reappears () null)
+(defun test-dropped-interrupt-hint-reappears ()
+  "Test contended presentation only delays the force-exit hint."
+  (let* ((now 0)
+         (terminal (make-instance 'recording-terminal :columns 80))
+         (ui (terminal-ui-create
+              :terminal terminal
+              :clock-function (lambda () now)))
+         (application (make-instance 'application :ui ui))
+         (gate (make-lock "Autolith hint contention test"))
+         (gate-condition (make-condition-variable :name "Autolith hint test"))
+         (holding-p nil)
+         (released-p nil)
+         (holder nil)
+         (controller
+           (make-instance
+            'application-input-controller
+            :application application
+            :later-state (make-instance 'later-state)
+            :pending-later-entries nil
+            :main-thread (current-thread)
+            :interrupt-clock-function (lambda () now))))
+    (setf (application-input-controller application) controller
+          (application-input-controller-active-p controller) t)
+    (application-input-controller--request-active-turn-cancellation
+     controller :force-exit-window-p t)
+    (setf now 1/2)
+    (setf holder
+          (make-thread
+           (lambda ()
+             (with-terminal-ui-locked (ui)
+               (with-lock-held (gate)
+                 (setf holding-p t)
+                 (condition-notify gate-condition)
+                 (loop until released-p
+                       do (condition-wait gate-condition gate)))))
+           :name "Autolith hint contention holder"))
+    (unwind-protect
+         (progn
+           (with-lock-held (gate)
+             (loop until holding-p
+                   do (condition-wait gate-condition gate :timeout 2)))
+           (application-input-controller--refresh-interrupt-hint controller)
+           (test-assert (null (terminal-ui-notice ui))
+                        "contended presentation drops the due hint")
+           (test-assert
+            (application-input-controller-interrupt-hint-time controller)
+            "a dropped hint stays due for a later reader pass"))
+      (with-lock-held (gate)
+        (setf released-p t)
+        (condition-notify gate-condition))
+      (join-thread holder))
+    (application-input-controller--refresh-interrupt-hint controller)
+    (test-assert (terminal-ui-notice ui)
+                 "the delayed hint appears once presentation is free")
+    (test-assert
+     (null (application-input-controller-interrupt-hint-time controller))
+     "a shown hint stops asking for another reader pass"))
+  nil)
+
+(-> test-active-cancellation-interrupt-window-expiry () null)
+(defun test-active-cancellation-interrupt-window-expiry ()
+  "Test an expired active-cancellation window requires a new timely press."
+  (let* ((now 0)
+         (terminal (make-instance 'recording-terminal :columns 80))
+         (ui (terminal-ui-create :terminal terminal))
+         (application (make-instance 'application :ui ui))
+         (forced-status nil)
+         (controller
+           (make-instance
+            'application-input-controller
+            :application application
+            :later-state (make-instance 'later-state)
+            :pending-later-entries nil
+            :main-thread (current-thread)
+            :interrupt-clock-function (lambda () now)
+            :forced-exit-function
+            (lambda (status)
+              (setf forced-status status)))))
+    (setf (application-input-controller application) controller
+          (application-input-controller-active-p controller) t)
+    (application-input-controller--process-event controller ':interrupt)
+    (test-assert
+     (= (application-input-controller-interrupt-deadline controller) 5/2)
+     "the first active Ctrl-C starts the 2.5-second window")
+    (setf now 3)
+    (application-input-controller--process-event controller ':interrupt)
+    (test-assert (null forced-status)
+                 "an expired second active Ctrl-C does not force exit")
+    (test-assert
+     (= (application-input-controller-interrupt-deadline controller) 11/2)
+     "an expired second active Ctrl-C starts a fresh window")
+    (setf now 5)
+    (application-input-controller--process-event controller ':interrupt)
+    (test-assert (= forced-status *application-forced-interrupt-status*)
+                 "a new timely second active Ctrl-C forces exit"))
+  nil)
+
+(-> test-cancellation-completion-clears-interrupt-state () null)
+(defun test-cancellation-completion-clears-interrupt-state ()
+  "Test completed cancellation clears force state and restores idle Ctrl-C."
+  (let* ((now 0)
+         (terminal (make-instance 'recording-terminal :columns 80))
+         (ui (terminal-ui-create :terminal terminal))
+         (application (make-instance 'application :ui ui))
+         (forced-status nil)
+         (controller
+           (make-instance
+            'application-input-controller
+            :application application
+            :later-state (make-instance 'later-state)
+            :pending-later-entries nil
+            :main-thread (current-thread)
+            :interrupt-clock-function (lambda () now)
+            :forced-exit-function
+            (lambda (status)
+              (setf forced-status status)))))
+    (setf (application-input-controller application) controller
+          (application-input-controller-active-p controller) t)
+    (application-input-controller--process-event controller ':interrupt)
+    (test-assert
+     (and (application-input-controller-turn-cancellation-p controller)
+          (application-input-controller-interrupt-deadline controller)
+          (application-input-controller-interrupt-hint-time controller))
+     "active Ctrl-C establishes cancellation lifecycle and force state")
+    (setf now 1/2)
+    (application-input-controller--refresh-interrupt-hint controller)
+    (test-assert (terminal-ui-notice ui)
+                 "a cancellation past the hint delay explains forced exit")
+    (application-input-controller--finish-work controller)
+    (test-assert
+     (and (not (application-input-controller-active-p controller))
+          (not (application-input-controller-turn-cancellation-p controller))
+          (not
+           (application-input-controller-turn-cancellation-delivery-pending-p
+            controller))
+          (null (application-input-controller-interrupt-deadline controller))
+          (null (application-input-controller-interrupt-hint-time controller))
+          (null (terminal-ui-notice ui)))
+     "turn cleanup clears cancellation delivery, deadline, and notice")
+    (application-input-controller--process-event controller ':interrupt)
+    (test-assert (application-input-controller-stopping-p controller)
+                 "the next empty-prompt Ctrl-C follows idle exit semantics")
+    (test-assert (eq (application-input-controller-exit-reason controller)
+                     ':interrupt)
+                 "post-cancellation idle Ctrl-C records ordinary interrupt exit")
+    (test-assert (null forced-status)
+                 "post-cancellation idle Ctrl-C never inherits forced exit")
+    (test-assert
+     (null (application-input-controller-interrupt-deadline controller))
+     "post-cancellation idle Ctrl-C does not arm a force window"))
   nil)
 
 (-> test-transcript-entries () null)
@@ -4684,7 +5538,18 @@
   (test-command-permission-modes)
   (test-interrupt-resume-instruction)
   (test-repeated-interrupt-forces-exit)
+  (test-forced-exit-without-durable-conversation)
   (test-graceful-shutdown-retains-interrupt-escape)
+  (test-active-turn-interrupt-events)
+  (test-idle-interrupt-exits-without-force-hint)
+  (test-active-turn-stop-keys)
+  (test-active-command-stop-key)
+  (test-active-tool-stop-repairs-unknown-outcome)
+  (test-interrupt-force-window)
+  (test-visible-interrupt-hint-does-not-extend-window)
+  (test-dropped-interrupt-hint-reappears)
+  (test-active-cancellation-interrupt-window-expiry)
+  (test-cancellation-completion-clears-interrupt-state)
   (test-transcript-entries)
   (test-task-run-call-presentation)
   (test-recovery-cursor-normalization)

--- a/tests/terminal-tests.lisp
+++ b/tests/terminal-tests.lisp
@@ -560,6 +560,18 @@
                  "Kitty keyboard protocol Ctrl-C requests interruption")
     (test-assert (eq (terminal-read-event terminal) :interrupt)
                  "xterm modifyOtherKeys Ctrl-C requests interruption"))
+  (dolist (case (list (list (string *terminal-escape-character*) ':escape)
+                       (list (string (code-char 3)) ':interrupt)))
+    (destructuring-bind (input expected) case
+      (let ((terminal
+              (make-instance 'stream-terminal
+                             :input-stream (make-string-input-stream input)
+                             :output-stream (make-string-output-stream)
+                             :input-file-descriptor 0
+                             :interactive-p t
+                             :columns 40)))
+        (test-assert (eq (terminal-read-event terminal) expected)
+                     "raw Escape and Ctrl-C retain semantic input events"))))
   (let* ((output (make-string-output-stream))
          (terminal
            (make-instance 'stream-terminal
@@ -569,17 +581,18 @@
     (terminal--enable-input-protocols terminal)
     (terminal--disable-input-protocols terminal)
     (let ((controls (get-output-stream-string output)))
-      (test-assert (and (search (format nil "~C[>1u"
-                                        *terminal-escape-character*)
-                                controls)
-                        (search (format nil "~C[>4;2m"
-                                        *terminal-escape-character*)
-                                controls))
-                   "terminal startup requests distinguishable modified keys")
-      (test-assert (search (format nil "~C[<u"
-                                   *terminal-escape-character*)
-                           controls)
-                   "terminal shutdown restores ordinary keyboard reporting")))
+      (test-assert (search (format nil "~C[>4;2m"
+                                  *terminal-escape-character*)
+                          controls)
+                   "terminal startup requests xterm modified key reports")
+      (test-assert (not (search (format nil "~C[>1u"
+                                       *terminal-escape-character*)
+                               controls))
+                   "terminal startup leaves Kitty Escape reporting disabled")
+      (test-assert (search (format nil "~C[>4;0m"
+                                  *terminal-escape-character*)
+                          controls)
+                   "terminal shutdown restores ordinary modified key reports")))
   nil)
 
 (-> test-terminal-live-region-layout () null)
@@ -850,6 +863,105 @@
         (declare (ignore display cursor))
         (test-assert (not (search "reasoning summary" text))
                      "a cleared preview disappears without entering scrollback"))))
+  nil)
+
+(-> test-terminal-transient-notice () null)
+(defun test-terminal-transient-notice ()
+  "Test transient notices expire without entering terminal scrollback."
+  (let* ((clock 0)
+         (terminal (make-instance 'recording-terminal :columns 60))
+         (ui (terminal-ui-create
+              :terminal terminal
+              :clock-function (lambda () clock))))
+    (with-terminal-ui (active-ui ui)
+      (terminal-ui-set-notice
+       active-ui
+       "Press Ctrl-C again within 2.5 seconds to force exit."
+       :duration-seconds 5/2)
+      (multiple-value-bind (text display cursor)
+          (terminal-ui--live-content active-ui)
+        (declare (ignore display cursor))
+        (test-assert (search "Press Ctrl-C again" text)
+                     "the transient notice appears in the live region"))
+      (setf clock 5/2)
+      (with-terminal-ui-locked (active-ui)
+        (terminal-ui-set-input active-ui "draft"))
+      (test-assert (null (terminal-ui-notice active-ui))
+                   "any locked repaint clears a notice at its deadline")
+      (multiple-value-bind (text display cursor)
+          (terminal-ui--live-content active-ui)
+        (declare (ignore display cursor))
+        (test-assert (not (search "Press Ctrl-C again" text))
+                     "the expired notice vanishes from the live region"))
+      (setf clock 10)
+      (terminal-ui-set-notice
+       active-ui
+       "Press Ctrl-C again within 2.5 seconds to force exit."
+       :duration-seconds 5/2)
+      (setf clock 25/2)
+      (test-assert (terminal-ui-refresh-status active-ui)
+                   "the reader refresh also repaints an expired notice")
+      (test-assert (null (terminal-ui-notice active-ui))
+                   "the reader refresh clears the renewed notice")))
+  nil)
+
+(-> test-terminal-notice-lock-contention () null)
+(defun test-terminal-notice-lock-contention ()
+  "Test notice updates never wait behind ordinary presentation work."
+  (let* ((terminal (make-instance 'recording-terminal :columns 60))
+         (ui (terminal-ui-create :terminal terminal))
+         (state-lock (make-lock "Autolith notice contention test"))
+         (condition (make-condition-variable
+                     :name "Autolith notice contention test"))
+         (ui-lock-held-p nil)
+         (release-ui-lock-p nil)
+         (notice-call-returned-p nil)
+         (holder nil)
+         (setter nil))
+    (terminal-ui-start ui)
+    (unwind-protect
+         (progn
+           (setf holder
+                 (make-thread
+                  (lambda ()
+                    (with-terminal-ui-locked (ui)
+                      (with-lock-held (state-lock)
+                        (setf ui-lock-held-p t)
+                        (condition-notify condition)
+                        (unless release-ui-lock-p
+                          (condition-wait condition state-lock :timeout 2)))))
+                  :name "Autolith notice lock holder"))
+           (test-assert
+            (task-tests--wait-until
+             (lambda ()
+               (with-lock-held (state-lock) ui-lock-held-p))
+             1)
+            "the contention test holds the presentation lock")
+           (setf setter
+                 (make-thread
+                  (lambda ()
+                    (terminal-ui-set-notice
+                     ui "must not appear" :duration-seconds 5/2)
+                    (with-lock-held (state-lock)
+                      (setf notice-call-returned-p t)
+                      (condition-notify condition)))
+                  :name "Autolith nonblocking notice setter"))
+           (test-assert
+            (task-tests--wait-until
+             (lambda ()
+               (with-lock-held (state-lock) notice-call-returned-p))
+             1)
+            "a notice update returns while presentation remains locked")
+           (test-assert (null (terminal-ui-notice ui))
+                        "a contended notice is dropped instead of delayed"))
+      (with-lock-held (state-lock)
+        (setf release-ui-lock-p t)
+        (condition-notify condition))
+      (when setter
+        (ignore-errors (join-thread setter)))
+      (when holder
+        (ignore-errors (join-thread holder)))
+      (ignore-errors (terminal-ui-stop ui))))
   nil)
 
 (-> test-terminal-timed-status () null)
@@ -1686,6 +1798,8 @@
   (test-terminal-narrow-live-region)
   (test-terminal-bounded-editor-repaint)
   (test-terminal-preview-rows)
+  (test-terminal-transient-notice)
+  (test-terminal-notice-lock-contention)
   (test-terminal-timed-status)
   (test-terminal-agent-activities)
   (test-terminal-stream-update)


### PR DESCRIPTION
Correct active turn cancellation semantics