### PR TITLE
feat: accept SBCL runtimes at or above the pinned minimum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,8 +238,9 @@ Materialize the locked project dependencies with:
 
 On macOS arm64, install a host SBCL, Quicklisp under `~/quicklisp`, Rust with
 Cargo, the Xcode command-line tools, CMake, `pkg-config`, and OpenSSL before
-running bootstrap. Bootstrap builds and records the exact pinned SBCL under the
-Autolith data root; it does not replace the Homebrew host SBCL.
+running bootstrap. Bootstrap records any host SBCL satisfying the tracked
+minimum version and installs its matching source under the Autolith data root;
+it never replaces the Homebrew host SBCL.
 
 Rebuild only the installed pristine recovery image with:
 

--- a/README.org
+++ b/README.org
@@ -79,9 +79,10 @@ installing a newer release. The check runs in the background and never installs
 anything unattended. A prior cached result may place an update notice below the
 next startup banner. Run =autolith --update= to check and update explicitly.
 
-Native macOS arm64 currently runs from a source checkout. Install the host
-toolchain and Quicklisp, then let bootstrap build and install the exact pinned
-SBCL, native libraries, recovery core, and active core:
+Native macOS arm64 currently runs from a source checkout. Autolith accepts any
+SBCL at least the version in =sbcl.version= (currently 2.6.4). Install the
+host toolchain and Quicklisp, then let bootstrap install the matching SBCL
+source, native libraries, recovery core, and active core:
 
 #+BEGIN_SRC sh
 brew install sbcl rust cmake pkg-config openssl@3

--- a/autolith.asd
+++ b/autolith.asd
@@ -33,6 +33,7 @@
                              (:file "core/json")
                              (:file "core/time")
                              (:file "core/source-files")
+                             (:file "core/streams")
                              (:file "configuration/settings")
                              (:file "configuration/workspace")
                              (:file "conversation/image-input")

--- a/bin/autolith
+++ b/bin/autolith
@@ -10,12 +10,7 @@ from_source_requested=false
 remaining_arguments=()
 state_home=${XDG_STATE_HOME:-$HOME/.local/state}
 data_home=${XDG_DATA_HOME:-$HOME/.local/share}
-runtime_version=$(tr -d '[:space:]' < "$source_root/sbcl.version")
-source_archive_sha256=$(tr -d '[:space:]' < "$source_root/sbcl-source.sha256")
-runtime_root=$data_home/autolith/runtimes/$runtime_version
-runtime_command_path=$data_home/autolith/runtimes/$runtime_version/command
-runtime_source_root=$runtime_root/source
-source_identity_path=$runtime_root/source.identity
+runtime_command_path=$data_home/autolith/runtimes/command
 inherited_runtime_source_root=${AUTOLITH_SBCL_SOURCE_ROOT:-}
 configured_sbcl=${AUTOLITH_SBCL:-}
 recorded_runtime=
@@ -30,18 +25,36 @@ else
   sbcl_command=sbcl
 fi
 export AUTOLITH_SBCL=$sbcl_command
-source_identity=
-if [[ -r "$source_identity_path" ]]; then
-  IFS= read -r source_identity < "$source_identity_path" || source_identity=
+selected_runtime_version=
+if [[ -d "$data_home/autolith/runtimes" ]] &&
+   selected_runtime_probe=$("$sbcl_command" --version 2>/dev/null); then
+  selected_runtime_version=${selected_runtime_probe#SBCL }
+  selected_runtime_version=${selected_runtime_version%% *}
 fi
+runtime_source_root=
+source_identity_path=
+source_identity=
+if [[ -n "$selected_runtime_version" ]]; then
+  runtime_source_root=$data_home/autolith/runtimes/$selected_runtime_version/source
+  source_identity_path=$data_home/autolith/runtimes/$selected_runtime_version/source.identity
+  if [[ -r "$source_identity_path" ]]; then
+    IFS= read -r source_identity < "$source_identity_path" || source_identity=
+  fi
+fi
+source_identity_version=${source_identity%% *}
+source_identity_sha256=${source_identity#* }
 if [[ "$inherited_runtime_source_root" == /* &&
       -f "$inherited_runtime_source_root/version.lisp-expr" ]] &&
-   grep -Fx "\"$runtime_version\"" \
-     "$inherited_runtime_source_root/version.lisp-expr" >/dev/null; then
+   { [[ -z "$selected_runtime_version" ]] ||
+     grep -Fx "\"$selected_runtime_version\"" \
+       "$inherited_runtime_source_root/version.lisp-expr" >/dev/null; }; then
   export AUTOLITH_SBCL_SOURCE_ROOT=$inherited_runtime_source_root
-elif [[ "$source_archive_sha256" =~ ^[0-9a-f]{64}$ &&
-      "$source_identity" == "$runtime_version $source_archive_sha256" &&
-      -f "$runtime_source_root/version.lisp-expr" ]]; then
+elif [[ -n "$runtime_source_root" &&
+      "$source_identity_version" == "$selected_runtime_version" &&
+      "$source_identity_sha256" =~ ^[0-9a-f]{64}$ &&
+      -f "$runtime_source_root/version.lisp-expr" ]] &&
+   grep -Fx "\"$source_identity_version\"" \
+     "$runtime_source_root/version.lisp-expr" >/dev/null; then
   export AUTOLITH_SBCL_SOURCE_ROOT=$runtime_source_root
 else
   unset AUTOLITH_SBCL_SOURCE_ROOT

--- a/bin/autolith-runtime
+++ b/bin/autolith-runtime
@@ -5,23 +5,25 @@ set -euo pipefail
 runtime_release=2.6.4
 runtime_archive_sha256=466933f9b4f403b6a49b2a7cc755fdd5d827c3b354aa3c8c0d96697e5da1e9fc
 runtime_archive_url=https://downloads.sourceforge.net/project/sbcl/sbcl/2.6.4/sbcl-2.6.4-x86-64-linux-binary.tar.bz2
-source_archive_url=https://downloads.sourceforge.net/project/sbcl/sbcl/2.6.4/sbcl-2.6.4-source.tar.bz2
+source_archive_base_url=https://downloads.sourceforge.net/project/sbcl/sbcl
 
 adapter_path=$(readlink -f -- "${BASH_SOURCE[0]}")
 source_root=$(CDPATH= cd -- "$(dirname -- "$adapter_path")/.." && pwd)
-expected_version=$(tr -d '[:space:]' < "$source_root/sbcl.version")
-source_archive_sha256=$(tr -d '[:space:]' < "$source_root/sbcl-source.sha256")
+minimum_version=$(tr -d '[:space:]' < "$source_root/sbcl.version")
+release_source_sha256=$(tr -d '[:space:]' < "$source_root/sbcl-source.sha256")
 data_home=${XDG_DATA_HOME:-$HOME/.local/share}
-runtime_root=$data_home/autolith/runtimes/$expected_version
-runtime_command_path=$runtime_root/command
-managed_prefix=$runtime_root/installation
+runtimes_root=$data_home/autolith/runtimes
+runtime_command_path=$runtimes_root/command
+managed_prefix=$runtimes_root/$runtime_release/installation
 managed_sbcl=$managed_prefix/bin/sbcl
-managed_source=$runtime_root/source
-source_identity_path=$runtime_root/source.identity
+runtime_root=
+managed_source=
+source_identity_path=
 install_requested=false
 script_path=
 script_arguments=()
 temporary_directory=
+selected_version=
 
 fail()
 {
@@ -43,6 +45,28 @@ runtime_version()
     --eval '(write-string (lisp-implementation-version))' 2>/dev/null
 }
 
+version_at_least()
+{
+  local IFS=.
+  local -a candidate_fields=($1)
+  local -a minimum_fields=($2)
+  local index candidate_field minimum_field
+
+  for index in 0 1 2; do
+    candidate_field=${candidate_fields[index]:-0}
+    minimum_field=${minimum_fields[index]:-0}
+    candidate_field=${candidate_field%%[!0-9]*}
+    minimum_field=${minimum_field%%[!0-9]*}
+    if ((10#${candidate_field:-0} > 10#${minimum_field:-0})); then
+      return 0
+    fi
+    if ((10#${candidate_field:-0} < 10#${minimum_field:-0})); then
+      return 1
+    fi
+  done
+  return 0
+}
+
 runtime_compatible()
 {
   local candidate=$1
@@ -52,7 +76,26 @@ runtime_compatible()
     return 1
   fi
   actual_version=$(runtime_version "$candidate") || return 1
-  [[ "$actual_version" == "$expected_version" ]]
+  [[ "$actual_version" =~ ^[0-9]+\.[0-9]+ ]] || return 1
+  if version_at_least "$actual_version" "$minimum_version"; then
+    selected_version=$actual_version
+    return 0
+  fi
+  return 1
+}
+
+sha256_of()
+{
+  local digest
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    digest=$(sha256sum -- "$1") || return 1
+  elif command -v shasum >/dev/null 2>&1; then
+    digest=$(shasum -a 256 -- "$1") || return 1
+  else
+    return 1
+  fi
+  printf '%s\n' "${digest%% *}"
 }
 
 runtime_resolve_command()
@@ -69,9 +112,9 @@ runtime_record()
   local command=$1
   local temporary
 
-  mkdir -p -- "$runtime_root"
-  chmod 700 "$runtime_root"
-  temporary=$runtime_root/.command.$$
+  mkdir -p -- "$runtimes_root"
+  chmod 700 "$runtimes_root"
+  temporary=$runtimes_root/.command.$$
   printf '%s\n' "$command" > "$temporary"
   chmod 444 "$temporary"
   mv -f -- "$temporary" "$runtime_command_path"
@@ -80,6 +123,8 @@ runtime_record()
 source_available()
 {
   local identity=
+  local identity_version=
+  local identity_sha256=
 
   if [[ ! -d "$managed_source" ||
         ! -f "$managed_source/version.lisp-expr" ||
@@ -87,36 +132,46 @@ source_available()
     return 1
   fi
   IFS= read -r identity < "$source_identity_path" || return 1
-  [[ "$identity" == "$expected_version $source_archive_sha256" ]]
+  identity_version=${identity%% *}
+  identity_sha256=${identity#* }
+  [[ "$identity_version" == "$selected_version" &&
+     "$identity_sha256" =~ ^[0-9a-f]{64}$ ]] || return 1
+  grep -Fxq "\"$identity_version\"" "$managed_source/version.lisp-expr"
 }
 
 source_install()
 {
+  local version=$selected_version
   local archive
+  local archive_sha256
   local distribution
   local identity
   local stale_source=
 
-  [[ "$expected_version" == "$runtime_release" ]] ||
-    fail "sbcl.version changed without matching source download metadata."
-  for command in curl sha256sum tar; do
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    fail "SBCL $version is not an official release with a published source archive; set AUTOLITH_SBCL to a release build."
+  for command in curl tar; do
     command -v -- "$command" >/dev/null 2>&1 ||
       fail "automatic source installation needs $command."
   done
 
   mkdir -p -- "$runtime_root"
-  chmod 700 "$runtime_root"
+  chmod 700 "$runtimes_root" "$runtime_root"
   temporary_directory=$(mktemp -d "$runtime_root/.source.XXXXXX")
-  archive=$temporary_directory/sbcl-$expected_version-source.tar.bz2
-  distribution=$temporary_directory/sbcl-$expected_version
+  archive=$temporary_directory/sbcl-$version-source.tar.bz2
+  distribution=$temporary_directory/sbcl-$version
 
-  printf 'Installing matching SBCL %s source for Autolith.\n' "$expected_version" >&2
+  printf 'Installing matching SBCL %s source for Autolith.\n' "$version" >&2
   curl --fail --location --show-error --retry 3 --progress-bar \
     --proto '=https' --tlsv1.2 \
-    --output "$archive" "$source_archive_url"
-  printf '%s  %s\n' "$source_archive_sha256" "$archive" |
-    sha256sum --check --status - ||
+    --output "$archive" \
+    "$source_archive_base_url/$version/sbcl-$version-source.tar.bz2"
+  archive_sha256=$(sha256_of "$archive") ||
+    fail "automatic source installation needs sha256sum or shasum."
+  if [[ "$version" == "$runtime_release" &&
+        "$archive_sha256" != "$release_source_sha256" ]]; then
     fail "the downloaded SBCL source archive has the wrong SHA-256 identity."
+  fi
   tar -xjf "$archive" -C "$temporary_directory"
   [[ -f "$distribution/version.lisp-expr" &&
      -f "$distribution/src/code/list.lisp" ]] ||
@@ -138,7 +193,7 @@ source_install()
     rm -rf -- "$stale_source"
   fi
   identity=$runtime_root/.source.identity.$$
-  printf '%s %s\n' "$expected_version" "$source_archive_sha256" > "$identity"
+  printf '%s %s\n' "$version" "$archive_sha256" > "$identity"
   chmod 444 "$identity"
   mv -f -- "$identity" "$source_identity_path"
   rm -rf -- "$temporary_directory"
@@ -147,6 +202,7 @@ source_install()
 
 runtime_install()
 {
+  local install_root=$runtimes_root/$runtime_release
   local archive
   local archive_name
   local command
@@ -154,29 +210,28 @@ runtime_install()
   local installation
   local stale_installation=
 
-  [[ "$expected_version" == "$runtime_release" ]] ||
-    fail "sbcl.version changed without matching runtime download metadata."
+  version_at_least "$runtime_release" "$minimum_version" ||
+    fail "sbcl.version requires a newer runtime than the pinned download."
   [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]] ||
-    fail "automatic installation currently supports Linux x86-64 only."
-  for command in curl sha256sum tar; do
+    fail "no SBCL $minimum_version or newer was found, and automatic runtime installation supports Linux x86-64 only. Install SBCL (for example: brew install sbcl) or set AUTOLITH_SBCL."
+  for command in curl tar; do
     command -v -- "$command" >/dev/null 2>&1 ||
       fail "automatic installation needs $command."
   done
 
-  mkdir -p -- "$runtime_root"
-  chmod 700 "$runtime_root"
-  temporary_directory=$(mktemp -d "$runtime_root/.install.XXXXXX")
-  archive_name=sbcl-$expected_version-x86-64-linux-binary.tar.bz2
+  mkdir -p -- "$install_root"
+  chmod 700 "$runtimes_root" "$install_root"
+  temporary_directory=$(mktemp -d "$install_root/.install.XXXXXX")
+  archive_name=sbcl-$runtime_release-x86-64-linux-binary.tar.bz2
   archive=$temporary_directory/$archive_name
-  distribution=$temporary_directory/sbcl-$expected_version-x86-64-linux
+  distribution=$temporary_directory/sbcl-$runtime_release-x86-64-linux
   installation=$temporary_directory/installation
 
-  printf 'Installing pinned SBCL %s for Autolith.\n' "$expected_version" >&2
+  printf 'Installing pinned SBCL %s for Autolith.\n' "$runtime_release" >&2
   curl --fail --location --show-error --retry 3 --progress-bar \
     --proto '=https' --tlsv1.2 \
     --output "$archive" "$runtime_archive_url"
-  printf '%s  %s\n' "$runtime_archive_sha256" "$archive" |
-    sha256sum --check --status - ||
+  [[ $(sha256_of "$archive") == "$runtime_archive_sha256" ]] ||
     fail "the downloaded SBCL archive has the wrong SHA-256 identity."
   tar -xjf "$archive" -C "$temporary_directory"
   [[ -x "$distribution/install.sh" ]] ||
@@ -189,7 +244,7 @@ runtime_install()
     fail "the installed SBCL runtime failed its version probe."
 
   if [[ -e "$managed_prefix" ]]; then
-    stale_installation=$runtime_root/installation.stale.$$
+    stale_installation=$install_root/installation.stale.$$
     mv -- "$managed_prefix" "$stale_installation"
   fi
   if ! mv -- "$installation" "$managed_prefix"; then
@@ -226,9 +281,9 @@ done
 
 [[ -n "$script_path" ]] || fail "no Lisp script was provided."
 [[ -f "$script_path" ]] || fail "Lisp script $script_path does not exist."
-[[ "$expected_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+[[ "$minimum_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
   fail "sbcl.version is malformed."
-[[ "$source_archive_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+[[ "$release_source_sha256" =~ ^[0-9a-f]{64}$ ]] ||
   fail "sbcl-source.sha256 is malformed."
 
 trap cleanup EXIT
@@ -241,7 +296,7 @@ if [[ -n ${AUTOLITH_SBCL:-} ]]; then
   sbcl_command=$(runtime_resolve_command "$AUTOLITH_SBCL") ||
     fail "AUTOLITH_SBCL does not name an executable."
   runtime_compatible "$sbcl_command" ||
-    fail "AUTOLITH_SBCL is not SBCL $expected_version."
+    fail "AUTOLITH_SBCL does not satisfy SBCL $minimum_version or newer."
 elif [[ -r "$runtime_command_path" ]]; then
   IFS= read -r recorded_command < "$runtime_command_path" || recorded_command=
   if [[ "$recorded_command" == /* ]] &&
@@ -264,8 +319,12 @@ if [[ -z "$sbcl_command" && "$install_requested" == true ]]; then
   sbcl_command=$managed_sbcl
 fi
 if [[ -z "$sbcl_command" ]]; then
-  fail "SBCL $expected_version is unavailable; run ./script/bootstrap."
+  fail "SBCL $minimum_version or newer is unavailable; run ./script/bootstrap."
 fi
+
+runtime_root=$runtimes_root/$selected_version
+managed_source=$runtime_root/source
+source_identity_path=$runtime_root/source.identity
 
 if [[ "$install_requested" == true ]] && ! source_available; then
   source_install

--- a/docs/architecture.org
+++ b/docs/architecture.org
@@ -306,10 +306,11 @@ launcher can use the core.
 
 ** =bin/= and =recovery/=
 
-Contain the stable launcher boundary, pinned-runtime adapter, and minimal
-recovery runtime. =script/bootstrap= locates or installs the pinned SBCL beneath the
-data root without changing the system Lisp. It also installs the independently
-hash-verified matching SBCL source as a read-only reference. It builds the
+Contain the stable launcher boundary, runtime adapter, and minimal
+recovery runtime. =script/bootstrap= locates an SBCL satisfying the tracked
+minimum version or, on Linux x86-64, installs the pinned SBCL beneath the
+data root without changing the system Lisp. It also installs the matching
+SBCL source as a read-only reference. It builds the
 recovery runtime into a read-only pristine core and builds the separate
 preloaded active image outside the repository. Both builders record exact
 source provenance and boot-probe each temporary image. The launcher repeats the

--- a/docs/autolith-minimal-technical-spec.org
+++ b/docs/autolith-minimal-technical-spec.org
@@ -1187,8 +1187,8 @@ Recovery must remain possible without loading the damaged active core.
 
 Autolith should include or locate:
 
-- A pinned SBCL runtime.
-- The exact source corresponding to the pinned SBCL runtime.
+- An SBCL runtime satisfying the tracked minimum version.
+- The exact source corresponding to the selected SBCL runtime.
 - A local, pinned Quicklisp distribution or equivalent dependency set.
 - Required Lisp source dependencies.
 - Bubblewrap and a private =cl-exec-sandbox= helper on Linux, or the system
@@ -1202,10 +1202,10 @@ Ordinary filesystem, process, networking, and build operations should
 prefer Common Lisp, ASDF, and UIOP.
 
 On Linux x86-64, setup may install a hash-verified pinned SBCL binary beneath
-the data root when no compatible runtime is available. On macOS arm64, setup
-uses a matching runtime or builds the pinned runtime from source with a host
-SBCL. The launcher and development commands use the private recorded executable
-without changing the user's system Lisp installation.
+the data root when no runtime satisfying the tracked minimum version is
+available. Elsewhere, setup requires an installed SBCL satisfying that
+minimum. The launcher and development commands use the private recorded
+executable without changing the user's system Lisp installation.
 
 The matching SBCL source is a reference and reconstruction input for
 implementation-aware inspection. Live implementation mutation changes only a

--- a/docs/guide.org
+++ b/docs/guide.org
@@ -16,7 +16,7 @@ on SBCL. It:
 - keeps finalized output in normal terminal scrollback;
 - runs =lisp.*= operations in named, heap-isolated SBCL REPLs;
 - saves modified worker heaps as immutable images with durable notes;
-- inspects the exact source matching its pinned SBCL runtime;
+- inspects the exact source matching its selected SBCL runtime;
 - exposes documented =self.*= inspection and mutation operations;
 - privately commits reconstructible live mutations without committing to Git;
 - saves live SBCL generations without stopping the active parent;
@@ -96,16 +96,19 @@ metadata compatibility record after the host checksum becomes available. See
 
 Source development needs Quicklisp, =curl=, =tar=, a SHA-256 utility, Rust
 with Cargo, a C compiler, CMake, and =pkg-config=. The tracked =sbcl.version=
-pins SBCL 2.6.4. On Linux, setup uses a matching =AUTOLITH_SBCL=, locates a
-matching system runtime, or installs the hash-verified official Linux x86-64
-binary. On macOS arm64, setup uses a matching runtime or builds the exact
-pinned runtime from source with a host SBCL. It installs that private runtime
-under the Autolith data root without replacing the system Lisp.
+names the minimum supported SBCL, currently 2.6.4. Setup uses
+=AUTOLITH_SBCL= or a system runtime whenever the probed version satisfies
+that minimum. On Linux, when no suitable runtime exists, setup installs the
+hash-verified official 2.6.4 x86-64 binary beneath the Autolith data root
+without replacing the system Lisp. On macOS arm64, install a suitable SBCL
+first, for example with Homebrew.
 
-Setup also downloads the official matching SBCL source archive, verifies its
-separately pinned SHA-256 identity, and publishes the extracted tree without
-write bits beside the runtime. The launcher and development commands remember
-that selection.
+Setup also downloads the official SBCL source archive matching the selected
+runtime's exact version and publishes the extracted tree without write bits
+beside the recorded runtime selection. The 2.6.4 archive is verified against
+the tracked SHA-256 identity; other release archives record their downloaded
+identity beside the tree. The launcher and development commands remember that
+selection.
 
 For a fresh macOS development machine, install the host build dependencies and
 Quicklisp first:
@@ -133,8 +136,9 @@ builds a small pristine recovery core under
 =${XDG_DATA_HOME:-~/.local/share}/autolith/recovery/=, and builds a preloaded
 active image under the adjacent =active/= directory. Both cores and their
 manifests are installed read-only. Matching implementation source lives under
-=${XDG_DATA_HOME:-~/.local/share}/autolith/runtimes/2.6.4/source/= and is used as
-a read-only inspection reference, never as a live patch target.
+=${XDG_DATA_HOME:-~/.local/share}/autolith/runtimes/<version>/source/=, a
+directory keyed by the selected runtime's exact version, and is used as a
+read-only inspection reference, never as a live patch target.
 
 The launcher probes the preloaded image against the current SBCL, operating
 system, architecture, and content hash of every Autolith source input plus the
@@ -822,9 +826,11 @@ ${XDG_DATA_HOME:-~/.local/share}/autolith/
 ├── lisp-images/IMAGE-ID/
 │   ├── manifest.sexp
 │   └── worker.core
-└── runtimes/2.6.4/
-    ├── installation/
-    └── source/
+└── runtimes/
+    ├── command
+    └── SBCL-VERSION/
+        ├── installation/
+        └── source/
 #+END_SRC
 
 Running Autolith with its own repository as the workspace turns it into an

--- a/script/bootstrap.lisp
+++ b/script/bootstrap.lisp
@@ -132,13 +132,8 @@ grandchild processes all land under the rail."
        (sbcl-command (or (uiop:getenv "AUTOLITH_SBCL") "sbcl"))
        (quicklisp-setup (merge-pathnames "quicklisp/setup.lisp"
                                          (user-homedir-pathname))))
-  (let ((expected-version
-          (string-trim '(#\Space #\Tab #\Newline #\Return)
-                       (uiop:read-file-string version-pathname))))
-    (unless (string= expected-version (lisp-implementation-version))
-      (error "Autolith pins SBCL ~A, but this process is ~A. Set AUTOLITH_SBCL to the pinned executable."
-             expected-version
-             (lisp-implementation-version))))
+  (load (merge-pathnames "script/runtime-requirement.lisp" source-root))
+  (autolith-require-minimum-runtime version-pathname)
   (unless (probe-file quicklisp-setup)
     (error "Autolith bootstrap needs Quicklisp at ~A" quicklisp-setup))
   (format t "~&~A~%" (bootstrap-style "35;1" "Autolith bootstrap"))

--- a/script/build-active.lisp
+++ b/script/build-active.lisp
@@ -20,13 +20,8 @@
           (or (first arguments)
               (uiop:getenv "AUTOLITH_ACTIVE_CORE")
               default-core))))
-  (let ((expected-version
-          (string-trim '(#\Space #\Tab #\Newline #\Return)
-                       (uiop:read-file-string version-pathname))))
-    (unless (string= expected-version (lisp-implementation-version))
-      (error "Active-image builds require pinned SBCL ~A, not ~A."
-             expected-version
-             (lisp-implementation-version))))
+  (load (merge-pathnames "script/runtime-requirement.lisp" source-root))
+  (autolith-require-minimum-runtime version-pathname)
   (unless (probe-file project-setup)
     (error "Active-image builds need locked dependencies; run ./script/bootstrap."))
   (format t "~&Loading Autolith for its preloaded active image.~%")

--- a/script/build-recovery.lisp
+++ b/script/build-recovery.lisp
@@ -25,13 +25,8 @@
        (quicklisp-setup (if (probe-file project-setup)
                            project-setup
                            user-setup)))
-  (let ((expected-version
-          (string-trim '(#\Space #\Tab #\Newline #\Return)
-                       (uiop:read-file-string version-pathname))))
-    (unless (string= expected-version (lisp-implementation-version))
-      (error "Recovery builds require pinned SBCL ~A, not ~A."
-             expected-version
-             (lisp-implementation-version))))
+  (load (merge-pathnames "script/runtime-requirement.lisp" source-root))
+  (autolith-require-minimum-runtime version-pathname)
   (labels ((load-recovery-source ()
              "Load only the packages needed to compile the recovery runtime."
              (unless (probe-file quicklisp-setup)

--- a/script/check.lisp
+++ b/script/check.lisp
@@ -10,13 +10,8 @@
        (quicklisp-setup (if (probe-file project-setup)
                            project-setup
                            user-setup)))
-  (let ((expected-version
-          (string-trim '(#\Space #\Tab #\Newline #\Return)
-                       (uiop:read-file-string version-pathname))))
-    (unless (string= expected-version (lisp-implementation-version))
-      (error "Autolith pins SBCL ~A, but this process is ~A."
-             expected-version
-             (lisp-implementation-version))))
+  (load (merge-pathnames "script/runtime-requirement.lisp" source-root))
+  (autolith-require-minimum-runtime version-pathname)
   (unless (probe-file quicklisp-setup)
     (error "Autolith needs Quicklisp at ~A" quicklisp-setup))
   (load quicklisp-setup)

--- a/script/runtime-requirement.lisp
+++ b/script/runtime-requirement.lisp
@@ -1,0 +1,29 @@
+;;;; Minimum SBCL runtime enforcement shared by standalone build scripts.
+
+(defun autolith-version-components (version)
+  "Return the leading numeric components of the dotted VERSION string."
+  (loop for field in (uiop:split-string version :separator ".")
+        for end = (or (position-if-not #'digit-char-p field) (length field))
+        while (plusp end)
+        collect (parse-integer field :end end)))
+
+(defun autolith-version-at-least-p (candidate minimum)
+  "Return whether dotted version CANDIDATE is at least dotted version MINIMUM."
+  (let ((candidate-components (autolith-version-components candidate))
+        (minimum-components (autolith-version-components minimum)))
+    (loop for index from 0 below (max (length candidate-components)
+                                      (length minimum-components))
+          for candidate-component = (or (nth index candidate-components) 0)
+          for minimum-component = (or (nth index minimum-components) 0)
+          when (> candidate-component minimum-component) return t
+          when (< candidate-component minimum-component) return nil
+          finally (return t))))
+
+(defun autolith-require-minimum-runtime (version-pathname)
+  "Signal an error unless this process satisfies the version at VERSION-PATHNAME."
+  (let ((minimum (string-trim '(#\Space #\Tab #\Newline #\Return)
+                              (uiop:read-file-string version-pathname))))
+    (unless (autolith-version-at-least-p (lisp-implementation-version) minimum)
+      (error "Autolith needs SBCL ~A or newer, but this process is SBCL ~A. Set AUTOLITH_SBCL to a suitable executable."
+             minimum
+             (lisp-implementation-version)))))

--- a/src/configuration/project-adaptations.lisp
+++ b/src/configuration/project-adaptations.lisp
@@ -475,7 +475,7 @@ discarded or obsolete candidates.
         (with-open-file (stream pathname
                                 :direction :input
                                 :external-format :utf-8)
-          (let ((count (read-sequence buffer stream)))
+          (let ((count (read-character-sequence buffer stream)))
             (if (> count content-limit)
                 (concatenate 'string
                              prefix

--- a/src/core/streams.lisp
+++ b/src/core/streams.lisp
@@ -1,0 +1,29 @@
+(in-package #:autolith)
+
+;;;; -- Bounded Character Reads --
+
+(defparameter *character-read-sequence-window* 256
+  "The largest single READ-SEQUENCE character request Autolith issues.
+
+SBCL 2.6.7 introduced SIMD utf-8 decoding that can overrun destination
+strings when one request asks for more than 256 characters at once. Requests
+at or below 256 characters stay on the portable buffered path on every
+supported runtime.")
+
+(-> read-character-sequence (string stream) (integer 0))
+(defun read-character-sequence (buffer stream)
+  "Fill BUFFER from STREAM like READ-SEQUENCE using bounded requests."
+  (let ((length (length buffer))
+        (filled 0))
+    (loop
+      (when (= filled length)
+        (return filled))
+      (let ((position
+              (read-sequence buffer stream
+                             :start filled
+                             :end (min length
+                                       (+ filled
+                                          *character-read-sequence-window*)))))
+        (when (= position filled)
+          (return filled))
+        (setf filled position)))))

--- a/src/provider/client.lisp
+++ b/src/provider/client.lisp
@@ -853,7 +853,7 @@ because the dependency chooses the element type from response headers."
        (handler-case
            (if (subtypep (stream-element-type stream) 'character)
                (let* ((buffer (make-string 4000))
-                      (end (read-sequence buffer stream)))
+                      (end (read-character-sequence buffer stream)))
                  (and (plusp end) (subseq buffer 0 end)))
                (let* ((buffer (make-array 4000 :element-type '(unsigned-byte 8)))
                       (end (read-sequence buffer stream)))

--- a/src/skills/runtime.lisp
+++ b/src/skills/runtime.lisp
@@ -610,7 +610,7 @@ stall discovery."
                        (setf *skill-definition-source-character-count*
                              character-limit)
                        (let* ((buffer (make-string (1+ character-limit)))
-                              (count (read-sequence buffer stream)))
+                              (count (read-character-sequence buffer stream)))
                          (setf *skill-definition-source-character-count* count)
                          (when (> count character-limit)
                            (skill--definition-fail

--- a/src/tools/workspace.lisp
+++ b/src/tools/workspace.lisp
@@ -231,7 +231,7 @@ historical line-window behavior, and an empty file has zero lines."
                               :direction :input
                               :external-format :utf-8)
         (loop
-          for count = (read-sequence buffer stream)
+          for count = (read-character-sequence buffer stream)
           until (zerop count)
           do
              (setf saw-character-p t

--- a/tests/mcp-tool-tests.lisp
+++ b/tests/mcp-tool-tests.lisp
@@ -2561,7 +2561,7 @@
               :name "cleanup-stdio"
               :transport
               `(:type :stdio
-                :command ,(namestring sb-ext:*runtime-pathname*)
+                :command ,(lisp-worker-sbcl-command)
                 :arguments
                 ("--noinform"
                  "--no-sysinit"
@@ -2765,7 +2765,7 @@
             :name "credential-rotation"
             :transport
             `(:type :stdio
-              :command ,(namestring sb-ext:*runtime-pathname*)
+              :command ,(lisp-worker-sbcl-command)
               :arguments
               ("--noinform"
                "--no-sysinit"

--- a/tests/release-script-tests.lisp
+++ b/tests/release-script-tests.lisp
@@ -193,6 +193,7 @@ fi
   "Check the remaining bootstrap shell boundaries and tracked Lisp programs."
   (dolist (relative '("bin/autolith"
                       "bin/autolith-release"
+                      "bin/autolith-runtime"
                       "script/build-release"
                       "script/build-release-runtime"
                       "server/build-in-container"))
@@ -204,6 +205,7 @@ fi
          (namestring (merge-pathnames "script/install" source-root)))
    :output nil)
   (dolist (relative '("script/build-release-runtime.lisp"
+                      "script/runtime-requirement.lisp"
                       "server/build-in-container.lisp"))
     (with-open-file (stream (merge-pathnames relative source-root)
                             :direction :input
@@ -700,6 +702,92 @@ mv -Tf \"$temporary\" \"$AUTOLITH_INSTALL_ROOT/current\"
      "the verified updater atomically selects the new release"))
   nil)
 
+(-> release-script-tests--runtime-adapter (pathname pathname) null)
+(defun release-script-tests--runtime-adapter (source-root root)
+  "Exercise minimum-version runtime selection in the pinned-runtime adapter."
+  (let* ((fixture-root (merge-pathnames "runtime-adapter/" root))
+         (bin-directory (merge-pathnames "bin/" fixture-root))
+         (data-home (merge-pathnames "data/" fixture-root))
+         (adapter (merge-pathnames "autolith-runtime" bin-directory))
+         (script (merge-pathnames "script.lisp" fixture-root)))
+    (uiop:ensure-all-directories-exist (list bin-directory data-home))
+    (uiop:copy-file (merge-pathnames "bin/autolith-runtime" source-root)
+                    adapter)
+    (release-script-tests--chmod "755" adapter)
+    (release-script-tests--write-file
+     (merge-pathnames "sbcl.version" fixture-root)
+     (format nil "2.6.4~%"))
+    (release-script-tests--write-file
+     (merge-pathnames "sbcl-source.sha256" fixture-root)
+     (format nil "~A~%" (make-string 64 :initial-element #\0)))
+    (release-script-tests--write-file script (format nil "(quit)~%"))
+    (flet ((fake-runtime (version)
+             (let ((pathname
+                     (merge-pathnames (format nil "sbcl-~A" version)
+                                      fixture-root)))
+               (release-script-tests--write-file
+                pathname
+                (format nil
+                        "#!/bin/sh
+set -eu
+case \" $* \" in
+  *'(write-string (lisp-implementation-version))'*) printf '%s' '~A' ;;
+  *' --script '*) printf 'ADAPTER-SCRIPT %s\\n' \"$*\" ;;
+esac
+"
+                        version))
+               (release-script-tests--chmod "755" pathname)
+               pathname))
+           (run-adapter (runtime)
+             (multiple-value-bind (output error-output status)
+                 (release-script-tests--run
+                  (list "/bin/sh" "-c"
+                        (format nil "~A --script ~A 2>&1"
+                                (namestring adapter)
+                                (namestring script)))
+                  :environment
+                  (list (format nil "XDG_DATA_HOME=~A" (namestring data-home))
+                        (format nil "AUTOLITH_SBCL=~A" (namestring runtime)))
+                  :ignore-error-status t)
+               (declare (ignore error-output))
+               (values (or output "") status))))
+      (multiple-value-bind (output status)
+          (run-adapter (fake-runtime "2.6.7"))
+        (test-assert (zerop status)
+                     "the adapter accepts a newer runtime than the minimum")
+        (test-assert (search "ADAPTER-SCRIPT" output)
+                     "the adapter runs the script on a newer runtime")
+        (test-assert
+         (probe-file
+          (merge-pathnames "autolith/runtimes/command" data-home))
+         "the adapter records the accepted runtime command"))
+      (multiple-value-bind (output status)
+          (run-adapter (fake-runtime "2.10.0"))
+        (test-assert (and (zerop status) (search "ADAPTER-SCRIPT" output))
+                     "the adapter compares version fields numerically"))
+      (multiple-value-bind (output status)
+          (run-adapter (fake-runtime "2.6.3"))
+        (test-assert (not (zerop status))
+                     "the adapter rejects a runtime older than the minimum")
+        (test-assert (search "does not satisfy SBCL 2.6.4 or newer" output)
+                     "the adapter explains a rejected older runtime")))
+    (let ((*package* (find-package "CL-USER")))
+      (load (merge-pathnames "script/runtime-requirement.lisp" source-root)))
+    (let ((at-least-p
+            (fdefinition
+             (find-symbol "AUTOLITH-VERSION-AT-LEAST-P" "CL-USER"))))
+      (test-assert (funcall at-least-p "2.6.4" "2.6.4")
+                   "the version requirement accepts the minimum itself")
+      (test-assert (funcall at-least-p "2.10.0" "2.6.4")
+                   "the version requirement compares fields numerically")
+      (test-assert (funcall at-least-p "2.7.0.123-gabc" "2.6.4")
+                   "the version requirement tolerates build suffixes")
+      (test-assert (not (funcall at-least-p "2.6.3" "2.6.4"))
+                   "the version requirement rejects older versions")
+      (test-assert (not (funcall at-least-p "1.9.9" "2.6.4"))
+                   "the version requirement rejects older major series"))
+    nil))
+
 (-> test-release-scripts () null)
 (defun test-release-scripts ()
   "Test shell bootstrap boundaries through Common Lisp fixtures."
@@ -712,6 +800,7 @@ mv -Tf \"$temporary\" \"$AUTOLITH_INSTALL_ROOT/current\"
     (unwind-protect
          (progn
            (release-script-tests--syntax source-root)
+           (release-script-tests--runtime-adapter source-root root)
            (release-script-tests--source-launcher source-root root)
            (release-script-tests--launcher source-root root)
            (release-script-tests--update-handoff source-root root)

--- a/tests/release-server-tests.lisp
+++ b/tests/release-server-tests.lisp
@@ -21,11 +21,15 @@
 
 (-> release-server-tests--git (pathname list) string)
 (defun release-server-tests--git (directory arguments)
-  "Run a quiet Git fixture command in DIRECTORY and return trimmed output."
+  "Run an isolated quiet Git fixture command in DIRECTORY and return output."
   (string-trim
    '(#\Space #\Tab #\Newline #\Return)
    (uiop:run-program
-    (append (list "git" "-C" (namestring directory)) arguments)
+    (append (list "env"
+                  "GIT_CONFIG_NOSYSTEM=1"
+                  "GIT_CONFIG_GLOBAL=/dev/null"
+                  "git" "-C" (namestring directory))
+            arguments)
     :output :string
     :error-output :output)))
 

--- a/tests/terminal-tests.lisp
+++ b/tests/terminal-tests.lisp
@@ -1721,6 +1721,24 @@
                  "non-interactive terminals never open the picker"))
   nil)
 
+(-> terminal-tests--call-without-host-size (function) t)
+(defun terminal-tests--call-without-host-size (function)
+  "Call FUNCTION while kernel and tput terminal sizes are unavailable.
+
+Resize tests drive size changes through COLUMNS and LINES, which the real
+resolution only consults after the kernel and tput sizes. Masking those host
+sources keeps the tests deterministic under an interactive terminal."
+  (test-call-with-function-replacements
+   (list (list 'terminal-file-descriptor-size
+               (lambda (file-descriptor)
+                 (declare (ignore file-descriptor))
+                 (values nil nil)))
+         (list 'terminal--query-dimension
+               (lambda (capability)
+                 (declare (ignore capability))
+                 nil)))
+   function))
+
 (-> test-terminal-modal-resize () null)
 (defun test-terminal-modal-resize ()
   "Test that a resize raised during modal input repaints before event dispatch."
@@ -1740,29 +1758,31 @@
          (ui (terminal-ui-create :terminal terminal))
          (items '((:name "alpha" :argument nil :description "first entry"))))
     (unwind-protect
-         (with-terminal-ui (active-ui ui)
-           (recording-terminal-reset terminal)
-           (test-assert
-            (string= (terminal-ui-select
-                      active-ui
-                      :title "pick"
-                      :items items
-                      :resize-callback
-                      #'application-pending-terminal-size)
-                     "alpha")
-            "submit still accepts the picker event received during resize")
-           (test-assert (= (terminal-columns terminal) 18)
-                        "a pending picker resize refreshes terminal columns")
-           (test-assert (= (terminal-rows terminal) 8)
-                        "a pending picker resize refreshes terminal rows")
-           (test-assert (null *terminal-resize-pending-p*)
-                        "the picker consumes the pending resize flag")
-           (test-assert
-            (= (terminal-tests--substring-count
-                "pick"
-                (recording-terminal-output terminal))
-               2)
-            "the picker repaints at the new width before submit exits"))
+         (terminal-tests--call-without-host-size
+          (lambda ()
+            (with-terminal-ui (active-ui ui)
+              (recording-terminal-reset terminal)
+              (test-assert
+               (string= (terminal-ui-select
+                         active-ui
+                         :title "pick"
+                         :items items
+                         :resize-callback
+                         #'application-pending-terminal-size)
+                        "alpha")
+               "submit still accepts the picker event received during resize")
+              (test-assert (= (terminal-columns terminal) 18)
+                           "a pending picker resize refreshes terminal columns")
+              (test-assert (= (terminal-rows terminal) 8)
+                           "a pending picker resize refreshes terminal rows")
+              (test-assert (null *terminal-resize-pending-p*)
+                           "the picker consumes the pending resize flag")
+              (test-assert
+               (= (terminal-tests--substring-count
+                   "pick"
+                   (recording-terminal-output terminal))
+                  2)
+               "the picker repaints at the new width before submit exits"))))
       (if previous-columns
           (sb-posix:setenv "COLUMNS" previous-columns 1)
           (sb-posix:unsetenv "COLUMNS"))
@@ -1789,16 +1809,21 @@
               (setf *terminal-resize-pending-p* t))))
          (ui (terminal-ui-create :terminal terminal)))
     (unwind-protect
-         (with-terminal-ui (active-ui ui)
-           (test-assert (eq (application-read-terminal-event active-ui)
-                            :submit)
-                        "the application preserves the event read during resize")
-           (test-assert (= (terminal-columns terminal) 19)
-                        "the application refreshes width before event dispatch")
-           (test-assert (= (terminal-rows terminal) 9)
-                        "the application refreshes height before event dispatch")
-           (test-assert (null *terminal-resize-pending-p*)
-                        "the application consumes a resize raised during read"))
+         (terminal-tests--call-without-host-size
+          (lambda ()
+            (with-terminal-ui (active-ui ui)
+              (test-assert
+               (eq (application-read-terminal-event active-ui) :submit)
+               "the application preserves the event read during resize")
+              (test-assert
+               (= (terminal-columns terminal) 19)
+               "the application refreshes width before event dispatch")
+              (test-assert
+               (= (terminal-rows terminal) 9)
+               "the application refreshes height before event dispatch")
+              (test-assert
+               (null *terminal-resize-pending-p*)
+               "the application consumes a resize raised during read"))))
       (if previous-columns
           (sb-posix:setenv "COLUMNS" previous-columns 1)
           (sb-posix:unsetenv "COLUMNS"))


### PR DESCRIPTION
## Summary

`sbcl.version` currently demands an exact SBCL (2.6.4), and the runtime
adapter can only satisfy it by downloading the official Linux x86-64 binary.
On macOS arm64 the documented flow (`brew install sbcl` then
`./script/bootstrap`) fails immediately with "automatic installation
currently supports Linux x86-64 only", because the build-from-source path
described in `docs/guide.org` and the technical specification was never
implemented and Homebrew has moved past 2.6.4.

This PR reinterprets `sbcl.version` as the minimum supported runtime for
source checkouts. Any SBCL at or above it is accepted; the hash-verified
2.6.4 Linux x86-64 binary remains the automatic fallback, and binary
releases and the release builder keep the exact pin unchanged.

## Runtime selection

- `bin/autolith-runtime` probes candidates and accepts any version
  satisfying the minimum (numeric field comparison, so 2.10.0 > 2.6.4).
- The matching SBCL source archive is now downloaded for the selected
  runtime's exact version. The 2.6.4 archive is still verified against the
  tracked `sbcl-source.sha256`; other release archives record their
  downloaded identity beside the tree.
- The runtimes cache is rekeyed: `runtimes/command` is the version
  independent selection pointer, and `runtimes/<version>/{source,...}` is
  keyed by the actual runtime version instead of the pinned one, so a 2.6.7
  source tree no longer lives in a directory named 2.6.4.
- The five standalone build scripts share one minimum-version check
  (`script/runtime-requirement.lisp`) instead of five exact `string=`
  checks. Image self-consistency checks (a core must match the runtime that
  built it) stay exact.

## Portability fixes surfaced by running the suite on a stock Mac

Running `./script/check` on macOS arm64 with Homebrew SBCL 2.6.7 surfaced
four latent issues, each fixed in its own commit:

1. **MCP stdio fixtures** spawned `sb-ext:*runtime-pathname*` with a
   scrubbed environment. Homebrew's real binary lives in `libexec/bin/` and
   cannot find `sbcl.core` without the wrapper's `SBCL_HOME`, so the child
   died and the transport reported "Could not write to the MCP stdio
   server". The fixtures now resolve the runtime through
   `lisp-worker-sbcl-command`, exactly as production workers do.
2. **SBCL 2.6.7 regression**: the "enhanced SIMD routines for UTF-8
   conversions" introduced in 2.6.7 overrun the destination string on arm64
   when a single `read-sequence` requests more than 256 characters
   (`INVALID-ARRAY-INDEX-ERROR` from
   `SB-IMPL::FD-STREAM-READ-SEQUENCE/UTF-8-TO-STRING`; observed with
   buffer sizes 257, 258, 511, and 4095 on plain ASCII input, while 256,
   512, 1000, 4096, and 65536 pass). The fast path is only entered for
   requests above 256 characters, so the new `read-character-sequence`
   in `src/core/streams.lisp` fills buffers in requests of at most 256
   characters and is used at the four character-stream call sites. This
   keeps every supported runtime on the portable path; I can file the
   upstream SBCL report with the minimal reproduction if useful.
3. **Git fixtures** in the release server tests inherited host
   configuration. With `tag.gpgsign=true`, a lightweight `git tag` becomes
   a signed tag that needs a message and a terminal, and exits 128. The
   fixture helper now runs Git with `GIT_CONFIG_NOSYSTEM=1` and
   `GIT_CONFIG_GLOBAL=/dev/null`, mirroring
   `release-archive--identity-git-command`.
4. **Resize tests** faked resizes through `COLUMNS`/`LINES`, but
   `terminal-current-size` prefers the kernel TTY size and `tput`, so the
   tests only passed when stdin was not a terminal. They now mask the two
   host size sources with `test-call-with-function-replacements` and
   deterministically exercise the environment fallback they were written
   for.

## Testing

- `./script/bootstrap` on macOS arm64 (M1) with Homebrew SBCL 2.6.7:
  installs the matching 2.6.7 source, builds fff, recovery core, and the
  preloaded active image.
- `./script/check`: 3,040 tests pass, both headless and under a PTY.
- New adapter regression tests cover minimum acceptance, numeric version
  comparison, rejection of older runtimes, and the version-comparison
  helper edge cases (including build-suffix versions like `2.7.0.123-gabc`).

Docs (`README.org`, `AGENTS.md`, `docs/guide.org`, `docs/architecture.org`,
and the specification) are updated to describe the minimum-version policy;
the spec change replaces the previously documented but unimplemented
macOS build-from-source path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
