### PR TITLE
Make Nix runs independent of source runtime

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -94,17 +94,18 @@ jobs:
             fail_smoke "Autolith first run exited with status $status" "$diagnostic"
           fi
           for artifact in \
-            "$XDG_DATA_HOME/autolith/recovery/autolith-recovery.core" \
-            "$XDG_DATA_HOME/autolith/recovery/manifest.sexp" \
-            "$XDG_DATA_HOME/autolith/active/autolith-active.core" \
-            "$XDG_DATA_HOME/autolith/active/manifest.sexp"; do
+            "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core" \
+            "$XDG_DATA_HOME/autolith/nix/active/manifest.sexp"; do
             if [ ! -f "$artifact" ]; then
-              fail_smoke "Autolith first run omitted an image artifact" "$artifact"
+              fail_smoke "Autolith first run omitted the writable Nix image layer" "$artifact"
             fi
           done
+          if [ -L "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core" ] || \
+             [ ! -w "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core" ]; then
+            fail_smoke "Autolith Nix image layer is not writable" \
+              "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core"
+          fi
           for marker in \
-            "Installed pristine recovery image" \
-            "Installed preloaded active image" \
             "AUTOLITH v"; do
             if ! grep -F "$marker" "$temporary_home/stdout" >/dev/null; then
               fail_smoke "Autolith first run omitted an output marker" "$marker"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+result
 *.fasl
 *.core
 .cache/

--- a/README.org
+++ b/README.org
@@ -74,8 +74,11 @@ curl -fsSL https://sh.lambda-symbolics.com/autolith | sh
 The binary release contains its own pinned SBCL, matching SBCL source, locked
 Lisp dependencies, search library, and private sandbox helper. It needs Git,
 OpenSSL, and Bubblewrap from the host. The Nix package carries its pristine
-recovery and preloaded active images in the store, so the first launch does not
-build either image or require Quicklisp, a compiler, or a source checkout.
+recovery and base active images in the store, so the first launch does not build
+either image or require Quicklisp, a compiler, or a source checkout. It
+materializes a writable active-image layer
+under =${XDG_DATA_HOME:-~/.local/share}/autolith/nix/active/= while leaving the
+store untouched, so private image commits survive restarts and Nix upgrades.
 Autolith checks published releases periodically and asks before
 installing a newer release. The check runs in the background and never installs
 anything unattended. A prior cached result may place an update notice below the

--- a/README.org
+++ b/README.org
@@ -73,9 +73,10 @@ curl -fsSL https://sh.lambda-symbolics.com/autolith | sh
 
 The binary release contains its own pinned SBCL, matching SBCL source, locked
 Lisp dependencies, search library, and private sandbox helper. It needs Git,
-OpenSSL, and Bubblewrap from the host. The first launch builds machine-specific
-recovery and active images without requiring Quicklisp, a compiler, or a source
-checkout. Autolith checks published releases periodically and asks before
+OpenSSL, and Bubblewrap from the host. The Nix package carries its pristine
+recovery and preloaded active images in the store, so the first launch does not
+build either image or require Quicklisp, a compiler, or a source checkout.
+Autolith checks published releases periodically and asks before
 installing a newer release. The check runs in the background and never installs
 anything unattended. A prior cached result may place an update notice below the
 next startup banner. Run =autolith --update= to check and update explicitly.

--- a/docs/guide.org
+++ b/docs/guide.org
@@ -42,8 +42,11 @@ runtime and native dependencies without borrowing them from the host.
 nix run github:luciusmagn/autolith
 #+END_SRC
 
-The first launch creates private recovery and active images without network
-access.
+The pristine recovery and base active images are carried in the Nix store.
+The first launch materializes a writable active-image layer beneath
+=${XDG_DATA_HOME:-~/.local/share}/autolith/nix/active/= without writing to the
+store. Private image commits and their replay scripts remain in the normal
+Autolith data and state roots, so live changes survive package restarts.
 
 ** Binary release
 

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,10 @@
             test -f "${autolith.activeImage}/active/autolith-active.core"
             test -f "${autolith.activeImage}/active/manifest.sexp"
             test ! -e "$XDG_DATA_HOME/autolith/recovery/autolith-recovery.core"
-            test ! -e "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core"
+            test -f "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core"
+            test -f "$XDG_DATA_HOME/autolith/nix/active/manifest.sexp"
+            test ! -L "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core"
+            test -w "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core"
 
             export COLORLISP_NATIVE_LIBRARY="${autolith.colorlispNativeLibrary}/lib/libcolorlisp-tree-sitter${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}"
             "${autolith.runtime}/bin/sbcl" \

--- a/flake.nix
+++ b/flake.nix
@@ -45,16 +45,21 @@
             export XDG_DATA_HOME="$HOME/.local/share"
             mkdir -p "$HOME"
             runtime_root="$XDG_DATA_HOME/autolith/runtimes/${pkgs.sbcl.version}"
-            mkdir -p "$runtime_root"
+            mkdir -p "$runtime_root/source"
+            printf '%s\n' 'unmanaged source tree' > \
+              "$runtime_root/source/generate-version.sh"
+            chmod 000 "$runtime_root/source/generate-version.sh"
             autolith --version >/dev/null
-            test ! -e "$runtime_root/command"
-            printf '%s\n' /managed/sbcl > "$runtime_root/command"
             test "$(autolith --version)" = "autolith ${autolith.autolithSystem.version}"
-            test "$(cat "$runtime_root/command")" = /managed/sbcl
-            printf '%s\n' \
-              "${autolith.runtime}/bin/sbcl" > "$runtime_root/command"
-            autolith --version >/dev/null
-            test ! -e "$runtime_root/command"
+            test -d "$runtime_root/source"
+            test ! -L "$runtime_root/source"
+            test -e "$runtime_root/source/generate-version.sh"
+            test -f "${autolith.recoveryImage}/recovery/autolith-recovery.core"
+            test -f "${autolith.recoveryImage}/recovery/manifest.sexp"
+            test -f "${autolith.activeImage}/active/autolith-active.core"
+            test -f "${autolith.activeImage}/active/manifest.sexp"
+            test ! -e "$XDG_DATA_HOME/autolith/recovery/autolith-recovery.core"
+            test ! -e "$XDG_DATA_HOME/autolith/nix/active/autolith-active.core"
 
             export COLORLISP_NATIVE_LIBRARY="${autolith.colorlispNativeLibrary}/lib/libcolorlisp-tree-sitter${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}"
             "${autolith.runtime}/bin/sbcl" \

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -389,13 +389,34 @@ pkgs.writeShellApplication {
     # retaining the user's conversations and other application data.
     nix_root="$data_home/autolith/nix"
     asdf_cache="$nix_root/asdf-cache/${builtins.baseNameOf (toString autolithSystem)}"
-    mkdir -p "$asdf_cache"
+    active_root="$nix_root/active"
+    active_core="$active_root/autolith-active.core"
+    active_manifest="$active_root/manifest.sexp"
+    mkdir -p "$asdf_cache" "$active_root"
     export AUTOLITH_ASDF_CACHE="$asdf_cache"
     export AUTOLITH_NIX_SOURCE_ROOT="${autolithSystem}/"
     export AUTOLITH_INSTALLATION_KIND=nix
 
+    # Nix store images are immutable. Materialize the packaged active image in
+    # a user-owned upper layer once, so a later image save or replacement never
+    # attempts to write into /nix/store. Keep the existing layer across package
+    # upgrades; private replay commits remain the source of durable mutations.
+    if [ ! -f "$active_core" ] || [ -L "$active_core" ]; then
+      temporary_core="$active_root/.autolith-active.core.$$"
+      cp "${activeImage}/active/autolith-active.core" "$temporary_core"
+      chmod u+w "$temporary_core"
+      mv -f "$temporary_core" "$active_core"
+    fi
+    if [ ! -f "$active_manifest" ] || [ -L "$active_manifest" ]; then
+      temporary_manifest="$active_root/.manifest.sexp.$$"
+      cp "${activeImage}/active/manifest.sexp" "$temporary_manifest"
+      chmod u+w "$temporary_manifest"
+      mv -f "$temporary_manifest" "$active_manifest"
+    fi
+    # An older writable copy may have retained the store's read-only mode.
+    chmod u+w "$active_core" "$active_manifest"
+
     recovery_core="${recoveryImage}/recovery/autolith-recovery.core"
-    active_core="${activeImage}/active/autolith-active.core"
     export AUTOLITH_RECOVERY_CORE="$recovery_core"
     export AUTOLITH_ACTIVE_CORE="$active_core"
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -302,6 +302,53 @@ let
     test -f "$out/src/code/list.lisp"
   '';
 
+  recoveryImage = pkgs.runCommand "autolith-recovery-${expectedSbclVersion}" {
+    nativeBuildInputs = [ pkgs.git ];
+  } ''
+    export HOME="$TMPDIR/home"
+    export XDG_DATA_HOME="$TMPDIR/data"
+    export AUTOLITH_SBCL="${runtime}/bin/sbcl"
+    export AUTOLITH_SBCL_SOURCE_ROOT="${sbclSource}"
+    export AUTOLITH_ASDF_CACHE="$TMPDIR/asdf-cache"
+    export AUTOLITH_NIX_SOURCE_ROOT="${autolithSystem}/"
+    export AUTOLITH_INSTALLATION_KIND=nix
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0=safe.directory
+    export GIT_CONFIG_VALUE_0="${autolithSystem}"
+    export GIT_OPTIONAL_LOCKS=0
+
+    mkdir -p "$HOME" "$AUTOLITH_ASDF_CACHE" "$out/recovery"
+    "$AUTOLITH_SBCL" --script "${autolithSystem}/script/build-recovery.lisp" \
+      "$out/recovery/autolith-recovery.core"
+    test -f "$out/recovery/autolith-recovery.core"
+    test -f "$out/recovery/manifest.sexp"
+  '';
+
+  activeImage = pkgs.runCommand "autolith-active-${expectedSbclVersion}" {
+    nativeBuildInputs = [ pkgs.git ];
+  } ''
+    export HOME="$TMPDIR/home"
+    export XDG_DATA_HOME="$TMPDIR/data"
+    export AUTOLITH_SBCL="${runtime}/bin/sbcl"
+    export AUTOLITH_SBCL_SOURCE_ROOT="${sbclSource}"
+    export AUTOLITH_ASDF_CACHE="$TMPDIR/asdf-cache"
+    export AUTOLITH_NIX_SOURCE_ROOT="${autolithSystem}/"
+    export AUTOLITH_INSTALLATION_KIND=nix
+    export COLORLISP_NATIVE_LIBRARY="${colorlispNativeLibrary}/lib/libcolorlisp-tree-sitter${sharedLibrary}"
+    export AUTOLITH_FFF_LIBRARY="${fffLibrary}/lib/libfff_c${sharedLibrary}"
+    ${sandboxEnvironment}
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0=safe.directory
+    export GIT_CONFIG_VALUE_0="${autolithSystem}"
+    export GIT_OPTIONAL_LOCKS=0
+
+    mkdir -p "$HOME" "$AUTOLITH_ASDF_CACHE" "$out/active"
+    "$AUTOLITH_SBCL" --script "${autolithSystem}/script/build-active.lisp" \
+      "$out/active/autolith-active.core"
+    test -f "$out/active/autolith-active.core"
+    test -f "$out/active/manifest.sexp"
+  '';
+
   # Sandboxing uses Bubblewrap and the private helper on Linux; other
   # platforms fall back to the portable unsandboxed path in cl-exec-sandbox.
   sandboxEnvironment = lib.optionalString pkgs.stdenv.isLinux ''
@@ -338,52 +385,19 @@ pkgs.writeShellApplication {
     export GIT_CONFIG_VALUE_0="${autolithSystem}"
     export GIT_OPTIONAL_LOCKS=0
 
-    runtime_root="$data_home/autolith/runtimes/${expectedSbclVersion}"
-    asdf_cache="$data_home/autolith/asdf-cache/${builtins.baseNameOf (toString autolithSystem)}"
-    mkdir -p "$runtime_root"
+    # Keep Nix-managed image and ASDF state separate from source installs while
+    # retaining the user's conversations and other application data.
+    nix_root="$data_home/autolith/nix"
+    asdf_cache="$nix_root/asdf-cache/${builtins.baseNameOf (toString autolithSystem)}"
     mkdir -p "$asdf_cache"
     export AUTOLITH_ASDF_CACHE="$asdf_cache"
     export AUTOLITH_NIX_SOURCE_ROOT="${autolithSystem}/"
     export AUTOLITH_INSTALLATION_KIND=nix
 
-    if [ "$(readlink "$runtime_root/source" 2>/dev/null || true)" != "${sbclSource}" ]; then
-      rm -rf "$runtime_root/source"
-      ln -s "${sbclSource}" "$runtime_root/source"
-    fi
-    printf '%s %s\n' \
-      "${expectedSbclVersion}" \
-      "${expectedSbclSourceHash}" > "$runtime_root/source.identity"
-    # The Nix runtime needs companion libraries and environment from this
-    # wrapper. Its bare persisted SBCL path would poison source-based tooling.
-    recorded_runtime=
-    if [ -r "$runtime_root/command" ]; then
-      IFS= read -r recorded_runtime < "$runtime_root/command" || recorded_runtime=
-    fi
-    case "$recorded_runtime" in
-      /nix/store/*-sbcl-with-packages*/bin/sbcl)
-        rm -f "$runtime_root/command"
-        ;;
-    esac
-
-    recovery_core="$data_home/autolith/recovery/autolith-recovery.core"
-    active_core="$data_home/autolith/active/autolith-active.core"
-
-    # Build the fast recovery + active images whenever the packaged Autolith
-    # changes (its store path is the upgrade signal) or an image is missing.
-    # Upstream's own bootstrap fetches SBCL and deps over the network, so we
-    # drive the offline build scripts directly with the Nix-provided runtime.
-    # We gate on the store path rather than re-deriving upstream's image-
-    # manifest validity check: a core that is corrupt without a version change
-    # is caught by the launcher we exec below, which re-validates and falls
-    # back to a (slower) source load.
-    build_marker="$data_home/autolith/images.built-for"
-    if [ ! -f "$recovery_core" ] || [ ! -f "$active_core" ] ||
-       [ "$(cat "$build_marker" 2>/dev/null || true)" != "${autolithSystem}" ]; then
-      echo "Building Autolith images (first run or package upgrade)..." >&2
-      "$AUTOLITH_SBCL" --script "${autolithSystem}/script/build-recovery.lisp"
-      "$AUTOLITH_SBCL" --script "${autolithSystem}/script/build-active.lisp"
-      printf '%s\n' "${autolithSystem}" > "$build_marker"
-    fi
+    recovery_core="${recoveryImage}/recovery/autolith-recovery.core"
+    active_core="${activeImage}/active/autolith-active.core"
+    export AUTOLITH_RECOVERY_CORE="$recovery_core"
+    export AUTOLITH_ACTIVE_CORE="$active_core"
 
     exec ${pkgs.bash}/bin/bash "${autolithSystem}/bin/autolith" "$@"
   '';
@@ -397,8 +411,8 @@ pkgs.writeShellApplication {
   };
 
   passthru = {
-    inherit autolithSystem clColorist clExecSandbox clifff clinedi colorlisp
-      colorlispNativeLibrary fffLibrary runtime sandboxHelper sbclSource
-      mcparen sbclWorkers sexpStore;
+    inherit activeImage autolithSystem clColorist clExecSandbox clifff clinedi
+      colorlisp colorlispNativeLibrary fffLibrary recoveryImage runtime
+      sandboxHelper sbclSource mcparen sbclWorkers sexpStore;
   };
 }

--- a/src/startup/active-image.lisp
+++ b/src/startup/active-image.lisp
@@ -127,8 +127,6 @@
                       (lisp-implementation-version))
              (string= (getf (rest record) :operating-system)
                       (software-type))
-             (string= (getf (rest record) :operating-system-version)
-                      (software-version))
              (string= (getf (rest record) :architecture)
                       (machine-type))
              (equal (mapcar #'first source-files)


### PR DESCRIPTION
This builds the startup image as a cacheable drv in isolation instead of interacting with the local environment