### PR TITLE
Declare object type in resource.edit anyOf variants

### DIFF
--- a/src/tools/defaults.lisp
+++ b/src/tools/defaults.lisp
@@ -95,10 +95,17 @@
                                 "enum" (vector name)))
              (let ((schema (tool-object-schema properties (cons "op" required))))
                (when any-required
+                 ;; Each anyOf variant must declare its object type: bare
+                 ;; {"required": [...]} subschemas are rejected by the
+                 ;; Fireworks JSON Schema validator ("could not understand the
+                 ;; instance"), which fails the whole request. The validated
+                 ;; instance is always an object here, so the type check does
+                 ;; not change the accepted operations.
                  (setf (gethash "anyOf" schema)
                        (map 'vector
                             (lambda (field)
-                              (json-object "required" (vector field)))
+                              (json-object "type" "object"
+                                           "required" (vector field)))
                             any-required)))
                schema)))
     (json-object

--- a/tests/resource-tests.lisp
+++ b/tests/resource-tests.lisp
@@ -286,3 +286,32 @@
      (string= (resource-revision-stale-actual-revision condition) "revision-2")
      "stale revision conditions retain the current revision"))
   nil)
+
+(-> test-resource-edit-operation-schema () null)
+(defun test-resource-edit-operation-schema ()
+  "Pin the resource.edit operation schema against provider validator limits.
+
+Bare {\"required\": [...]} anyOf variants carry no type declaration, and the
+Fireworks JSON Schema validator rejects them with \"could not understand the
+instance\", failing the entire request before the model runs. Every anyOf
+variant must therefore declare its object type explicitly."
+  (let* ((schema (default-tools--resource-operation-schema))
+         (variants (json-get schema "oneOf"))
+         (anyof-count 0))
+    (test-assert (and (vectorp variants) (plusp (length variants)))
+                 "resource.edit operations offer one closed variant per operation")
+    (loop for variant across variants
+          for any-of = (and (json-object-p variant) (json-get variant "anyOf"))
+          when any-of
+          do (loop for entry across any-of
+                   do (incf anyof-count)
+                      (test-assert
+                       (string= (or (json-get entry "type") "") "object")
+                       "anyOf variants declare their object type for provider validators")
+                      (test-assert
+                       (and (vectorp (json-get entry "required"))
+                            (plusp (length (json-get entry "required"))))
+                       "anyOf variants retain their required-field constraint")))
+    (test-assert (= anyof-count 3)
+                 "the agenda-update operation requires one of text, status, or memory-ids"))
+  nil)

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -162,6 +162,7 @@
     (test-openai-compatible-provider)
     (test-fireworks-provider)
     (test-resource-protocol)
+    (test-resource-edit-operation-schema)
     (test-lisp-source-balance)
     (test-lisp-source-edit-warnings)
     (test-workspace-file-resources)


### PR DESCRIPTION
## Problem

After upgrading past v0.24.0 (present in v0.25.1 and still in v0.26.1), every
turn on the █[PROVIDER CREDENTIAL REDACTED]█ provider (`accounts/█[PROVIDER CREDENTIAL REDACTED]█/models/*`) fails
before the model runs:

```
invalid_request_error: JSON Schema not supported: could not understand
the instance `{'required': ['text']}`.
```

The `resource.edit` tool schema expresses the `agenda-update`
at-least-one-field constraint as `anyOf` variants containing only
`{"required": [field]}`. Bare required-only subschemas carry no `type`, and
the █[PROVIDER CREDENTIAL REDACTED]█ Responses API's JSON Schema validator rejects them,
failing the entire request. Any conversation that advertises
`resource.edit` is therefore unusable on █[PROVIDER CREDENTIAL REDACTED]█, while other
providers accept the same schema.

## Fix

Declare `"type": "object"` in each `anyOf` variant. The validated instance
is always an operation object, so the set of accepted operations is
unchanged.

## Verification

- Reproduced against the live █[PROVIDER CREDENTIAL REDACTED]█ Responses endpoint: the bare
  variant returns the exact production 400 above; the typed variant
  completes with HTTP 200.
- New regression test `test-resource-edit-operation-schema` pins every
  `anyOf` variant to declare its object type and retain its `required`
  constraint.
- Full suite passes: `asdf:test-system :autolith` on SBCL 2.6.4 with
  qlfile.lock dependencies.
