### PR TITLE
Fix unknown type specifier crash in the /auth command

### DIFF
--- a/src/application/commands.lisp
+++ b/src/application/commands.lisp
@@ -1246,7 +1246,7 @@ to TERMINAL-UI-SELECT."
        :reasoning-summaries-p (application-reasoning-traces-p application))
       (application-provider application)))
 
-(-> application-authenticate (application &optional provider-name) null)
+(-> application-authenticate (application &optional (option string)) null)
 (defun application-authenticate (application &optional provider-name)
   "Authenticate APPLICATION's active or named provider."
   (let* ((ui (application-ui application))

--- a/tests/application-command-tests.lisp
+++ b/tests/application-command-tests.lisp
@@ -323,6 +323,51 @@
          (format nil "~A has terminal ownership ~S" input expected)))))
   nil)
 
+(-> test-application-authentication-provider-type () null)
+(defun test-application-authentication-provider-type ()
+  "Test that /auth accepts an optional provider name without a type failure."
+  (let* ((ui (terminal-ui-create
+              :terminal (make-instance 'recording-terminal :columns 80)))
+         (application (make-instance 'application :ui ui))
+         (provider (make-instance 'model-provider))
+         (selected-provider-name nil)
+         (stopped-p nil)
+         (started-p nil))
+    (test-call-with-function-replacements
+     (list
+      (list
+       'application--authentication-provider
+       (lambda (candidate provider-name)
+         (declare (ignore candidate))
+         (setf selected-provider-name provider-name)
+         provider))
+      (list
+       'terminal-ui-stop
+       (lambda (candidate)
+         (declare (ignore candidate))
+         (setf stopped-p t)
+         nil))
+      (list
+       'terminal-ui-start
+       (lambda (candidate)
+         (declare (ignore candidate))
+         (setf started-p t)
+         nil)))
+     (lambda ()
+       (test-assert
+        (handler-case
+            (progn
+              (application-authenticate application "grok")
+              nil)
+          (authentication-error ()
+            t))
+        "/auth reaches provider authentication without an unknown type failure")
+       (test-assert
+        (and stopped-p started-p
+             (string= selected-provider-name "grok"))
+        "/auth forwards the named provider and restores terminal ownership"))))
+  nil)
+
 (-> run-application-command-tests () boolean)
 (defun run-application-command-tests ()
   "Run application command protocol tests and return true."
@@ -330,4 +375,5 @@
   (test-application-command-registry)
   (test-application-command-policies)
   (test-built-in-application-command-policies)
+  (test-application-authentication-provider-type)
   t)


### PR DESCRIPTION
Fixes #20.

## Problem

Running `/auth` in the TUI — with or without a provider argument — crashes
Autolith into the recovery image on every invocation (exit status 70).
Full diagnosis in #20; the short version:

The ftype declaration for `application-authenticate` uses the defun's
parameter name where a type specifier belongs:

    (-> application-authenticate (application &optional provider-name) null)

No `provider-name` type is defined anywhere, so SBCL signals
`unknown type specifier: AUTOLITH::PROVIDER-NAME` (a `SIMPLE-ERROR`) when it
parses the declared ftype on the first call — even when the optional argument
is not supplied. Because the condition is not an `autolith-error`, the crash
capsule records only "Unexpected condition of type SIMPLE-ERROR." with no
backtrace, hiding the cause.

The headless `autolith --auth PROVIDER` path is unaffected:
`main-authenticate` calls `provider-authenticate` directly and never enters
`application-authenticate`.

## Fix

Declare the optional provider name as `(option string)`, matching the
signature of `provider-authentication-provider`, which the value is passed to.
One-line change to `src/application/commands.lisp`.

## Verification

- Minimal reproduction of the mechanism in plain SBCL 2.6.4: declaring
  `(ftype (function (t &optional no-such-type) null) f)` makes any call to
  `f` signal `unknown type specifier: NO-SUCH-TYPE`, including calls that
  omit the optional argument.
- Before: on v0.27.0 and master (nix flake build, macOS aarch64-darwin,
  SBCL 2.6.4), `/auth chatgpt` crashes to recovery immediately, before any
  network request. Reproducible on a completely fresh XDG state.
- After: with this change, `/auth chatgpt` proceeds to the ChatGPT device
  login (verification URL + one-time code) and completes normally.