### PR TITLE
Support reasoning-free Fireworks models and register qwen3p7-plus

### DIFF
--- a/src/provider/builtins.lisp
+++ b/src/provider/builtins.lisp
@@ -84,7 +84,11 @@
  :family ':fireworks
  :protocol ':responses
  :models '((:name "accounts/fireworks/models/kimi-k3"
-            :context-window 1048576))
+            :context-window 1048576)
+           ;; Fireworks advertises a 262k token context window.
+           (:name "accounts/fireworks/models/qwen3p7-plus"
+            :context-window 262144
+            :reasoning-efforts ("none")))
  :factory #'provider--fireworks-registration-factory
  :authenticator #'provider--fireworks-registration-authenticator
  :endpoint *fireworks-responses-endpoint*

--- a/src/provider/fireworks/client.lisp
+++ b/src/provider/fireworks/client.lisp
@@ -58,11 +58,29 @@
 
 ;;;; -- Fireworks Protocol Specializations --
 
+(defparameter *fireworks-reasoning-effort-models-blacklist* '()
+  "Fireworks model identifiers whose serving stacks reject any reasoning
+effort parameter.  Requests for these models must omit the reasoning
+object entirely; see PROVIDER-RESPONSES-WIRE-EFFORT.")
+
+(-> fireworks-model-reasoning-effort-p (string) boolean)
+(defun fireworks-model-reasoning-effort-p (model)
+  "Return true when MODEL accepts a reasoning effort parameter."
+  (not (member model *fireworks-reasoning-effort-models-blacklist*
+               :test #'string=)))
+
+
 (defmethod provider-responses-wire-effort
     ((provider fireworks-api-key-provider) (configuration configuration))
-  "Return CONFIGURATION's Fireworks reasoning effort."
+  "Return CONFIGURATION's Fireworks reasoning effort, or NIL to omit it.
+
+Models in *fireworks-reasoning-effort-models-blacklist* reject every
+reasoning effort value at the serving stack, so NIL tells the shared
+request builder to omit the reasoning object entirely."
   (declare (ignore provider))
-  (configuration-fireworks-wire-effort configuration))
+  (when (fireworks-model-reasoning-effort-p
+         (configuration-model configuration))
+    (configuration-fireworks-wire-effort configuration)))
 
 (defmethod provider-responses-request-fields
     ((provider fireworks-api-key-provider) (conversation conversation))

--- a/src/provider/fireworks/client.lisp
+++ b/src/provider/fireworks/client.lisp
@@ -58,7 +58,12 @@
 
 ;;;; -- Fireworks Protocol Specializations --
 
-(defparameter *fireworks-reasoning-effort-models-blacklist* '()
+;; Verified 2026-08-11 against the live Fireworks Responses API: every
+;; effort level Autolith can send (low, medium, high) fails for this model
+;; with a 404 'Model not found, inaccessible, and/or not deployed', while
+;; omitting the reasoning object succeeds.
+(defparameter *fireworks-reasoning-effort-models-blacklist*
+  '("accounts/fireworks/models/qwen3p7-plus")
   "Fireworks model identifiers whose serving stacks reject any reasoning
 effort parameter.  Requests for these models must omit the reasoning
 object entirely; see PROVIDER-RESPONSES-WIRE-EFFORT.")

--- a/src/provider/wire-protocol.lisp
+++ b/src/provider/wire-protocol.lisp
@@ -107,10 +107,12 @@
         copy)
       item))
 
-(-> provider-responses-wire-effort (responses-api-provider configuration) string)
+(-> provider-responses-wire-effort (responses-api-provider configuration) (option string))
 (defgeneric provider-responses-wire-effort (provider configuration)
   (:documentation
-   "Return CONFIGURATION's reasoning effort encoded for PROVIDER."))
+   "Return CONFIGURATION's reasoning effort encoded for PROVIDER.
+NIL means the serving stack rejects the reasoning parameter entirely;
+the request builder then omits the reasoning object."))
 
 (-> provider-responses-hosted-tool
     (responses-api-provider configuration)
@@ -220,12 +222,14 @@ after a completed response."
                    "tools" tools)
              (when (plusp (length tools))
                (list "tool_choice" "auto"))
-             (list "parallel_tool_calls" false
-                   "reasoning"
-                   (json-object
-                    "effort"
-                    (provider-responses-wire-effort provider configuration))
-                   "store" false
+             (list "parallel_tool_calls" false)
+             ;; A NIL wire effort means the serving stack rejects the
+             ;; reasoning parameter entirely; omit the reasoning object.
+             (let ((effort
+                     (provider-responses-wire-effort provider configuration)))
+               (when effort
+                 (list "reasoning" (json-object "effort" effort))))
+             (list "store" false
                    "stream" t)
              (provider-responses-request-fields provider conversation)))
      delivery)))

--- a/tests/fireworks-provider-tests.lisp
+++ b/tests/fireworks-provider-tests.lisp
@@ -203,6 +203,13 @@
                                            "effort")
                                  "high")
                         "default Ultra reasoning clamps to Fireworks high effort")
+           (test-assert (fireworks-model-reasoning-effort-p
+                         "accounts/fireworks/models/kimi-k3")
+                        "kimi-k3 keeps reasoning effort support")
+           (test-assert
+            (not (fireworks-model-reasoning-effort-p
+                  "accounts/fireworks/models/qwen3p7-plus"))
+            "qwen3p7-plus is registered as reasoning-effort-free")
            (test-assert (eq (json-get request "store") false)
                         "Fireworks requests never store server-side responses")
            (test-assert (eq (json-get request "stream") t)
@@ -230,6 +237,41 @@
              (test-assert
               (zerop (length (json-get compaction-request "tools")))
               "compaction requests carry no tools")))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist :ignore)))
+  nil)
+
+(-> fireworks-provider-test--reasoning-omission () null)
+(defun fireworks-provider-test--reasoning-omission ()
+  "Test that reasoning-effort-free models omit the reasoning request object."
+  (let* ((base-configuration
+           (configuration-with-model (test-configuration) "accounts/fireworks/models/qwen3p7-plus"))
+         (root (test-configuration-root base-configuration))
+         (configuration
+           (configuration--clone base-configuration
+                                 :working-directory root)))
+    (unwind-protect
+         (let* ((conversation (conversation-create configuration
+                                                   :identifier "fireworks-qwen-shape"))
+                (provider (fireworks-provider-create configuration))
+                (request nil))
+           (conversation-append-user-message conversation "hello")
+           (setf request (provider-request-object provider conversation #()))
+           (test-assert (string= (json-get request "model") "accounts/fireworks/models/qwen3p7-plus")
+                        "the request names the reasoning-free model")
+           (test-assert
+            (equal (configuration--reasoning-efforts-for
+                    (configuration-model configuration))
+                   '("none"))
+            "qwen3p7-plus offers no ignored reasoning choices")
+           (multiple-value-bind (reasoning present-p)
+               (gethash "reasoning" request)
+             (declare (ignore reasoning))
+             (test-assert (not present-p)
+                          "reasoning-free models omit the reasoning object"))
+           (test-assert (eq (json-get request "store") false)
+                        "store=false still rides reasoning-free requests")
+           (test-assert (eq (json-get request "stream") t)
+                        "streaming still rides reasoning-free requests"))
       (uiop:delete-directory-tree root :validate t :if-does-not-exist :ignore)))
   nil)
 
@@ -268,5 +310,6 @@
   (fireworks-provider-test--credential-source)
   (fireworks-provider-test--wire-tools)
   (fireworks-provider-test--request-shape)
+  (fireworks-provider-test--reasoning-omission)
   (fireworks-provider-test--static-authentication-rejection)
   nil)

--- a/tests/openai-compatible-provider-tests.lisp
+++ b/tests/openai-compatible-provider-tests.lisp
@@ -686,6 +686,7 @@
                            "gpt-5.6-terra"
                            "grok-4.5"
                            "accounts/fireworks/models/kimi-k3"
+                           "accounts/fireworks/models/qwen3p7-plus"
                            "claude-opus-5"
                            "claude-sonnet-5"
                            "claude-haiku-4-5-20251001"


### PR DESCRIPTION
## Summary

Some fireworks serving stacks reject every reasoning effort parameter. Verified
against the live fireworks Responses API on 2026-08-11 with
`accounts/fireworks/models/qwen3p7-plus`:

- `reasoning: {effort: "low" | "medium" | "high"}` -> 404 "Model not found,
  inaccessible, and/or not deployed"
- `reasoning: {effort: "max"}` -> 400 "non-reasoning model does not support
  reasoning_effort"
- omitting the `reasoning` object entirely -> 200, normal completion

Autolith's shared Responses request builder sent `reasoning` unconditionally,
so these models could not serve an Autolith session at all.

## Changes

Three small commits:

1. **Allow providers to omit the Responses reasoning parameter**:
   `provider-responses-wire-effort` may now return NIL, in which case the
   shared request builder omits the `reasoning` object. Existing providers
   always return a string, so their behavior is unchanged.
2. **Skip reasoning effort for blacklisted fireworks models**: the fireworks
   provider returns NIL for models in
   `*fireworks-reasoning-effort-models-blacklist*`, keeping the policy local to
   the fireworks provider.
3. **Register fireworks qwen3p7-plus**: adds the model to the fireworks provider
   registration (conservative 262144 context window; the fireworks model listing
   reports no window for it), enters it in the blacklist with the probe
   evidence, and covers the omission behavior with tests.

qwen3p7-plus is the only currently served fireworks model with image input, tool
use, and chat, so enabling it unlocks vision-capable sessions on fireworks.

## Test plan

- New `fireworks-provider-test--reasoning-omission` covers that blacklisted
  models omit `reasoning` while `store`/`stream` fields are retained; the
  existing request-shape test asserts kimi-k3 keeps its reasoning effort.
- The openai-compatible provider test's registered-model order expectation
  now includes qwen3p7-plus.
- `./script/check`: 4,339 tests pass.
