### PR TITLE
Support macOS arm64 standalone binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,50 @@ jobs:
           done
           printf 'GitHub metadata for %s is published, but the release service has not published the Linux archive checksum yet.\n' "$GITHUB_REF_NAME" >&2
           exit 0
+
+  package-macos-arm64:
+    name: Package macOS arm64
+    needs: publish-metadata
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          brew install rust
+
+      - name: Build pinned SBCL release runtime
+        run: |
+          runtime_version=$(tr -d '[:space:]' < sbcl.version)
+          data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+          runtime_root="$data_home/autolith/runtimes/$runtime_version"
+          mkdir -p "$runtime_root"
+          ./script/build-release-runtime "$runtime_root/installation"
+
+      - name: Install Quicklisp
+        run: |
+          runtime_version=$(tr -d '[:space:]' < sbcl.version)
+          data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+          runtime_root="$data_home/autolith/runtimes/$runtime_version"
+          curl -O https://beta.quicklisp.org/quicklisp.lisp
+          "$runtime_root/installation/bin/sbcl" --noinform --non-interactive \
+            --load quicklisp.lisp \
+            --eval '(quicklisp-quickstart:install :path "~/quicklisp")'
+
+      - name: Bootstrap release dependencies
+        run: |
+          ./script/bootstrap
+
+      - name: Build macOS release archive
+        run: |
+          ./script/build-release dist/
+
+      - name: Upload macOS release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" \
+            dist/autolith-"$GITHUB_REF_NAME"-arm64-darwin.tar.gz \
+            dist/autolith-"$GITHUB_REF_NAME"-arm64-darwin.tar.gz.sha256 \
+            --clobber

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ another requirement, stop and ask.
 
 Supported source-development targets are Linux x86-64 and macOS arm64 on SBCL
 with a terminal interface, one primary agent, and no claim of hostile-code
-sandboxing. Nix builds support Linux x86-64 and macOS arm64; packaged binary
-releases remain Linux x86-64.
+sandboxing. Nix builds and packaged binary releases support Linux x86-64 and
+macOS arm64.
 
 ## Upstream References
 

--- a/README.org
+++ b/README.org
@@ -42,20 +42,21 @@ but it is pretty close to a Lisp Machine.
 
 * Install
 
-Autolith supports Linux x86-64 and macOS arm64 via Nix. Packaged binary
-releases are available for Linux x86-64, but not yet for macOS (good first issue? hmm?).
+Autolith supports Linux x86-64 and macOS arm64 via standalone binary releases
+and Nix.
 
-Nix supplies the complete runtime:
-
-#+BEGIN_SRC sh
-nix run github:luciusmagn/autolith
-#+END_SRC
-
-A Linux curl-into-sh installer is also available. Inspect the
+The curl-into-sh installer installs or updates the packaged release for your
+platform (Linux x86-64 and macOS arm64). Inspect the
 [[https://sh.lambda-symbolics.com/autolith][installer script]] before piping it into a shell, or trust us with your life.
 
 #+BEGIN_SRC sh
 curl -fsSL https://sh.lambda-symbolics.com/autolith | sh
+#+END_SRC
+
+Nix also supplies the complete runtime:
+
+#+BEGIN_SRC sh
+nix run github:luciusmagn/autolith
 #+END_SRC
 
 Authenticate providers either with web flows or API keys:

--- a/bin/autolith-release
+++ b/bin/autolith-release
@@ -2,17 +2,37 @@
 
 set -euo pipefail
 
+resolve_path()
+{
+  local path=$1
+  local directory
+  local target
+
+  case "$path" in
+    /*) ;;
+    *) path=$PWD/$path ;;
+  esac
+  while [[ -L "$path" ]]; do
+    directory=$(CDPATH= cd -P "$(dirname "$path")" && pwd) || return 1
+    target=$(readlink "$path") || return 1
+    case "$target" in
+      /*) path=$target ;;
+      *) path=$directory/$target ;;
+    esac
+  done
+  directory=$(CDPATH= cd -P "$(dirname "$path")" && pwd) || return 1
+  printf '%s/%s\n' "$directory" "$(basename "$path")"
+}
+
 release_latest_url=${AUTOLITH_RELEASE_LATEST_URL:-https://sh.lambda-symbolics.com/releases/latest}
-launcher_path=$(readlink -f -- "${BASH_SOURCE[0]}")
-release_root=$(CDPATH= cd -- "$(dirname -- "$launcher_path")/.." && pwd)
+launcher_path=$(resolve_path "${BASH_SOURCE[0]}")
+release_root=$(CDPATH= cd -P -- "$(dirname -- "$launcher_path")/.." && pwd)
 release_record=$release_root/RELEASE
 source_root=$release_root/libexec/autolith
 runtime_root=$release_root/runtime
 runtime_source_root=$release_root/libexec/sbcl-source
 sbcl_command=$runtime_root/bin/sbcl
 sandbox_helper=$release_root/libexec/cl-exec-sandbox-helper
-fff_library=$release_root/lib/libfff_c.so
-colorlisp_library=$release_root/lib/libcolorlisp-tree-sitter.so
 home=${HOME:-}
 data_home=${XDG_DATA_HOME:-$home/.local/share}
 active_core=$data_home/autolith/active/autolith-active.core
@@ -150,13 +170,24 @@ release_images_build()
   mkdir -p -- "$marker_directory"
   temporary_marker=$marker_directory/.release-images.$$
   printf '%s\n' "$release_tag" > "$temporary_marker"
-  chmod 600 -- "$temporary_marker"
+  chmod 600 "$temporary_marker"
   mv -f -- "$temporary_marker" "$image_marker"
 }
 
 [[ -n $home ]] || fail "HOME is not set."
-[[ $(uname -s) == Linux && $(uname -m) == x86_64 ]] ||
-  fail "binary releases currently support Linux x86-64 only."
+platform=
+if [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]]; then
+  platform=x86_64-linux
+  fff_library=$release_root/lib/libfff_c.so
+  colorlisp_library=$release_root/lib/libcolorlisp-tree-sitter.so
+elif [[ $(uname -s) == Darwin && $(uname -m) == arm64 ]]; then
+  platform=arm64-darwin
+  fff_library=$release_root/lib/libfff_c.dylib
+  colorlisp_library=$release_root/lib/libcolorlisp-tree-sitter.dylib
+else
+  fail "binary releases currently support Linux x86-64 and macOS arm64 only."
+fi
+
 [[ -r $release_record ]] || fail "RELEASE is missing."
 release_version=$(release_field version)
 release_tag=$(release_field tag)
@@ -170,19 +201,23 @@ semantic_version_valid_p "$release_version" || fail "RELEASE has an invalid vers
 [[ -f $source_root/autolith.asd && -f $source_root/.qlot/setup.lisp ]] ||
   fail "the bundled Autolith source or dependencies are missing."
 [[ -x $source_root/script/install ]] || fail "the bundled installer is missing."
-[[ -x $sandbox_helper ]] || fail "the private sandbox helper is missing."
+if [[ $platform == x86_64-linux ]]; then
+  [[ -x $sandbox_helper ]] || fail "the private sandbox helper is missing."
+fi
 [[ -f $fff_library ]] || fail "the private search library is missing."
 [[ -f $colorlisp_library ]] || fail "the private syntax library is missing."
 command -v git >/dev/null 2>&1 || fail "Git is required."
-command -v bwrap >/dev/null 2>&1 || fail "Bubblewrap is required."
+if [[ $platform == x86_64-linux ]]; then
+  command -v bwrap >/dev/null 2>&1 || fail "Bubblewrap is required."
+fi
 
-releases_root=$(CDPATH= cd -- "$release_root/.." && pwd)
-install_root=$(CDPATH= cd -- "$releases_root/.." && pwd)
+releases_root=$(CDPATH= cd -P -- "$release_root/.." && pwd)
+install_root=$(CDPATH= cd -P -- "$releases_root/.." && pwd)
 selected_release_p=false
+current_selected=$(resolve_path "$install_root/current" 2>/dev/null || true)
 if [[ ${release_root##*/} == "$release_tag" &&
       ${releases_root##*/} == releases &&
-      $(readlink -f -- "$install_root/current" 2>/dev/null || true) == \
-        "$release_root" ]]; then
+      "$current_selected" == "$release_root" ]]; then
   selected_release_p=true
 fi
 
@@ -198,9 +233,11 @@ export AUTOLITH_FFF_LIBRARY=$fff_library
 export COLORLISP_NATIVE_LIBRARY=$colorlisp_library
 export AUTOLITH_ACTIVE_CORE=$active_core
 export AUTOLITH_RECOVERY_CORE=$recovery_core
-export CL_EXEC_SANDBOX_BWRAP
-CL_EXEC_SANDBOX_BWRAP=$(command -v bwrap)
-export CL_EXEC_SANDBOX_HELPER=$sandbox_helper
+if [[ $platform == x86_64-linux ]]; then
+  export CL_EXEC_SANDBOX_BWRAP
+  CL_EXEC_SANDBOX_BWRAP=$(command -v bwrap)
+  export CL_EXEC_SANDBOX_HELPER=$sandbox_helper
+fi
 export GIT_OPTIONAL_LOCKS=0
 
 remaining_arguments=("$@")

--- a/bin/autolith-runtime
+++ b/bin/autolith-runtime
@@ -251,7 +251,7 @@ runtime_install()
   version_at_least "$runtime_release" "$minimum_version" ||
     fail "sbcl.version requires a newer runtime than the pinned download."
   [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]] ||
-    fail "no SBCL $minimum_version or newer was found, and automatic runtime installation supports Linux x86-64 only. Install SBCL (for example: brew install sbcl) or set AUTOLITH_SBCL."
+    fail "no SBCL $minimum_version or newer was found, and automatic runtime binary installation supports Linux x86-64 only. On macOS, install SBCL (for example: brew install sbcl) or set AUTOLITH_SBCL."
   for command in curl tar; do
     command -v -- "$command" >/dev/null 2>&1 ||
       fail "automatic installation needs $command."

--- a/script/build-release
+++ b/script/build-release
@@ -2,7 +2,29 @@
 
 set -euo pipefail
 
-launcher_path=$(readlink -f -- "${BASH_SOURCE[0]}")
-source_root=$(CDPATH= cd -- "$(dirname -- "$launcher_path")/.." && pwd)
+resolve_path()
+{
+  local path=$1
+  local directory
+  local target
+
+  case "$path" in
+    /*) ;;
+    *) path=$PWD/$path ;;
+  esac
+  while [[ -L "$path" ]]; do
+    directory=$(CDPATH= cd -P "$(dirname "$path")" && pwd) || return 1
+    target=$(readlink "$path") || return 1
+    case "$target" in
+      /*) path=$target ;;
+      *) path=$directory/$target ;;
+    esac
+  done
+  directory=$(CDPATH= cd -P "$(dirname "$path")" && pwd) || return 1
+  printf '%s/%s\n' "$directory" "$(basename "$path")"
+}
+
+launcher_path=$(resolve_path "${BASH_SOURCE[0]}")
+source_root=$(CDPATH= cd -P -- "$(dirname -- "$launcher_path")/.." && pwd)
 
 exec "$source_root/server/run" archive "$@"

--- a/script/build-release-runtime
+++ b/script/build-release-runtime
@@ -2,14 +2,47 @@
 
 set -euo pipefail
 
-launcher_path=$(readlink -f -- "${BASH_SOURCE[0]}")
-source_root=$(CDPATH= cd -- "$(dirname -- "$launcher_path")/.." && pwd)
+resolve_path()
+{
+  local path=$1
+  local directory
+  local target
+
+  case "$path" in
+    /*) ;;
+    *) path=$PWD/$path ;;
+  esac
+  while [[ -L "$path" ]]; do
+    directory=$(CDPATH= cd -P "$(dirname "$path")" && pwd) || return 1
+    target=$(readlink "$path") || return 1
+    case "$target" in
+      /*) path=$target ;;
+      *) path=$directory/$target ;;
+    esac
+  done
+  directory=$(CDPATH= cd -P "$(dirname "$path")" && pwd) || return 1
+  printf '%s/%s\n' "$directory" "$(basename "$path")"
+}
+
+launcher_path=$(resolve_path "${BASH_SOURCE[0]}")
+source_root=$(CDPATH= cd -P -- "$(dirname -- "$launcher_path")/.." && pwd)
 installation=${1:?usage: build-release-runtime INSTALLATION}
 bootstrap_version=2.4.0
-bootstrap_sha256=50afb9765d6a2f937f609ac33ebe553326347aef23eddd49c46d76456a5b3095
+
+if [[ $(uname -s) == Linux && $(uname -m) == x86_64 ]]; then
+  bootstrap_arch="x86-64-linux"
+  bootstrap_sha256=50afb9765d6a2f937f609ac33ebe553326347aef23eddd49c46d76456a5b3095
+elif [[ $(uname -s) == Darwin && $(uname -m) == arm64 ]]; then
+  bootstrap_arch="arm64-darwin"
+  bootstrap_sha256=1d01fac2d9748f769c9246a0a11a2c011d7843337f8f06ca144f5a500e10c117
+else
+  printf 'build-release-runtime currently supports Linux x86-64 and macOS arm64.\n' >&2
+  exit 1
+fi
+
 temporary_root=$(mktemp -d)
-bootstrap_archive=$temporary_root/sbcl-$bootstrap_version-x86-64-linux-binary.tar.bz2
-bootstrap_source=$temporary_root/sbcl-$bootstrap_version-x86-64-linux
+bootstrap_archive=$temporary_root/sbcl-$bootstrap_version-$bootstrap_arch-binary.tar.bz2
+bootstrap_source=$temporary_root/sbcl-$bootstrap_version-$bootstrap_arch
 bootstrap_installation=$temporary_root/bootstrap
 
 cleanup()
@@ -20,13 +53,25 @@ cleanup()
 
 trap cleanup EXIT HUP INT TERM
 
+sha256_verify()
+{
+  local expected=$1
+  local file=$2
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s  %s\n' "$expected" "$file" | sha256sum --check --status
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s  %s\n' "$expected" "$file" | shasum -a 256 --check --status
+  else
+    return 1
+  fi
+}
+
 printf 'Installing the pinned SBCL %s bootstrap compiler.\n' "$bootstrap_version"
 curl --fail --location --show-error --retry 3 \
   --proto '=https' --tlsv1.2 \
   --output "$bootstrap_archive" \
-  "https://downloads.sourceforge.net/project/sbcl/sbcl/$bootstrap_version/sbcl-$bootstrap_version-x86-64-linux-binary.tar.bz2"
-printf '%s  %s\n' "$bootstrap_sha256" "$bootstrap_archive" |
-  sha256sum --check --status
+  "https://downloads.sourceforge.net/project/sbcl/sbcl/$bootstrap_version/sbcl-$bootstrap_version-$bootstrap_arch-binary.tar.bz2"
+sha256_verify "$bootstrap_sha256" "$bootstrap_archive"
 tar -xjf "$bootstrap_archive" -C "$temporary_root"
 (
   cd "$bootstrap_source"

--- a/script/build-release-runtime.lisp
+++ b/script/build-release-runtime.lisp
@@ -52,17 +52,38 @@
                                :output output
                                :error-output error-output))
 
+           (command-available-p (name)
+             "Return true when executable NAME is available in PATH."
+             (loop for directory-name
+                   in (uiop:split-string (or (uiop:getenv "PATH") "")
+                                         :separator '(#\:))
+                   thereis (and (plusp (length directory-name))
+                                (probe-file (merge-pathnames
+                                             name
+                                             (uiop:ensure-directory-pathname
+                                              directory-name))))))
+
            (check-archive (archive expected-sha256)
              "Require ARCHIVE to match EXPECTED-SHA256."
-             (run (list "sha256sum" "--check" "--status" "-")
-                  :output nil
-                  :error-output ':output
-                  :directory temporary-root
-                  :input
-                  (make-string-input-stream
-                   (format nil "~A  ~A~%"
-                           expected-sha256
-                           (file-namestring archive)))))
+             (if (command-available-p "sha256sum")
+                 (run (list "sha256sum" "--check" "--status" "-")
+                      :output nil
+                      :error-output ':output
+                      :directory temporary-root
+                      :input
+                      (make-string-input-stream
+                       (format nil "~A  ~A~%"
+                               expected-sha256
+                               (file-namestring archive))))
+                 (run (list "shasum" "-a" "256" "--check" "--status" "-")
+                      :output nil
+                      :error-output ':output
+                      :directory temporary-root
+                      :input
+                      (make-string-input-stream
+                       (format nil "~A  ~A~%"
+                               expected-sha256
+                               (file-namestring archive))))))
 
            (runtime-version (command)
              "Return the implementation version reported by SBCL COMMAND."
@@ -80,11 +101,15 @@
                        source-root installation temporary-root
                        bootstrap-installation)
             (fail "usage: build-release-runtime.lisp SOURCE INSTALLATION TEMP BOOTSTRAP"))
-          (unless (and (string-equal (software-type) "Linux")
-                       (member (string-downcase (machine-type))
-                               '("x86-64" "x86_64" "amd64")
-                               :test #'string=))
-            (fail "release runtimes currently support Linux x86-64 only."))
+          (unless (or (and (string-equal (software-type) "Linux")
+                           (member (string-downcase (machine-type))
+                                   '("x86-64" "x86_64" "amd64")
+                                   :test #'string=))
+                      (and (string-equal (software-type) "Darwin")
+                           (member (string-downcase (machine-type))
+                                   '("arm64" "aarch64")
+                                   :test #'string=)))
+            (fail "release runtimes currently support Linux x86-64 and macOS arm64 only."))
           (let* ((runtime-version
                    (trimmed-file (merge-pathnames "sbcl.version" source-root)))
                  (runtime-sha256

--- a/script/install
+++ b/script/install
@@ -52,6 +52,18 @@ release_installed_p()
     "$release_installed_target/RELEASE" >/dev/null 2>&1
 }
 
+check_sha256()
+{
+  check_checksum=$1
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum --check --status "$check_checksum"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 --check --status "$check_checksum"
+  else
+    return 1
+  fi
+}
+
 publish_links()
 {
   publish_target=$1
@@ -63,10 +75,12 @@ publish_links()
     fail "$install_root/current is a directory, not an installation link."
   fi
   ln -s "releases/$publish_tag" "$current_temporary"
-  mv -Tf -- "$current_temporary" "$install_root/current"
+  rm -f -- "$install_root/current"
+  mv -f -- "$current_temporary" "$install_root/current"
   if [ "$publish_command_p" = true ]; then
     mkdir -p -- "$bin_directory"
     ln -s "$install_root/current/bin/autolith" "$command_temporary"
+    rm -f -- "$bin_directory/autolith"
     mv -f -- "$command_temporary" "$bin_directory/autolith"
   fi
 }
@@ -86,7 +100,7 @@ while [ "$#" -gt 0 ]; do
       printf '%s\n' \
         'usage: install [--version vMAJOR.MINOR.PATCH] [--without-command-link]' \
         '' \
-        'Install or update the Autolith Linux x86-64 binary release.'
+        'Install or update the Autolith binary release.'
       exit 0
       ;;
     *)
@@ -96,12 +110,28 @@ while [ "$#" -gt 0 ]; do
 done
 
 [ -n "$home" ] || fail "HOME is not set."
-[ "$(uname -s)" = Linux ] && [ "$(uname -m)" = x86_64 ] ||
-  fail "binary releases currently support Linux x86-64 only. On macOS, install Autolith with Nix: nix run github:luciusmagn/autolith."
-for command in bash bwrap curl git grep openssl sha256sum tar; do
+platform=
+os=$(uname -s)
+arch=$(uname -m)
+if [ "$os" = Linux ] && [ "$arch" = x86_64 ]; then
+  platform=x86_64-linux
+elif [ "$os" = Darwin ] && [ "$arch" = arm64 ]; then
+  platform=arm64-darwin
+else
+  fail "binary releases currently support Linux x86-64 and macOS arm64 only."
+fi
+
+required_commands="bash curl git grep openssl tar"
+if [ "$platform" = x86_64-linux ]; then
+  required_commands="$required_commands bwrap"
+fi
+for command in $required_commands; do
   command -v "$command" >/dev/null 2>&1 ||
     fail "$command is required. Nix is the recommended installation path when system dependencies are unavailable."
 done
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+  fail "sha256sum or shasum is required."
+fi
 
 if [ -z "$requested_tag" ]; then
   requested_tag=$(release_latest_tag) ||
@@ -113,13 +143,13 @@ case $requested_tag in
 esac
 release_tag_valid_p "$requested_tag" || fail "the requested release tag is malformed."
 
-release_name=autolith-$requested_tag-x86_64-linux
+release_name=autolith-$requested_tag-$platform
 archive_name=$release_name.tar.gz
 checksum_name=$archive_name.sha256
 releases_root=$install_root/releases
 target=$releases_root/$requested_tag
 mkdir -p -- "$releases_root"
-chmod 700 -- "$install_root" "$releases_root"
+chmod 700 "$install_root" "$releases_root"
 
 if release_installed_p "$target" "$requested_tag"; then
   publish_links "$target" "$requested_tag"
@@ -139,12 +169,12 @@ else
     --proto '=https' --tlsv1.2 --output "$checksum" "$checksum_url"
   (
     cd -- "$temporary_root"
-    sha256sum --check --status "$checksum_name"
+    check_sha256 "$checksum_name"
   ) || fail "the release archive has the wrong SHA-256 identity."
   tar -xzf "$archive" -C "$temporary_root"
   release_installed_p "$extracted" "$requested_tag" ||
     fail "the release archive has an unexpected layout."
-  chmod u+w -- "$extracted" ||
+  chmod u+w "$extracted" ||
     fail "the verified release directory could not be prepared for publication."
 
   stale_target=
@@ -158,7 +188,7 @@ else
     fi
     fail "the verified release could not be published."
   fi
-  chmod u-w -- "$target" ||
+  chmod u-w "$target" ||
     fail "the published release permissions could not be restored."
   publish_links "$target" "$requested_tag"
   if [ -n "$stale_target" ] && [ -e "$stale_target" ]; then

--- a/server/release-archive.lisp
+++ b/server/release-archive.lisp
@@ -150,16 +150,8 @@
 (-> release-archive--link-target (pathname) (option pathname))
 (defun release-archive--link-target (link)
   "Return LINK's canonical existing target, or NIL for a broken link."
-  (multiple-value-bind (output error-output status)
-      (uiop:run-program (list "readlink" "-f" "--" (namestring link))
-                        :ignore-error-status t
-                        :output ':string
-                        :error-output ':string)
-    (declare (ignore error-output))
-    (let ((name (string-trim '(#\Newline #\Return) output)))
-      (when (and (eql status 0) (plusp (length name)))
-        (let ((target (pathname name)))
-          (and (probe-file target) target))))))
+  (let ((target (ignore-errors (truename link))))
+    (and target (probe-file target) target)))
 
 (-> release-archive--materialize-dependency-links (pathname) null)
 (defun release-archive--materialize-dependency-links (dependency-root)
@@ -279,17 +271,76 @@
    (release-archive--identity-git-command source-root '("read-tree" "HEAD")))
   nil)
 
+(-> release-archive--platform () string)
+(defun release-archive--platform ()
+  "Return the canonical release platform identifier."
+  (let ((os (software-type))
+        (arch (string-downcase (machine-type))))
+    (cond
+      ((and (string-equal os "Linux")
+            (member arch '("x86-64" "x86_64" "amd64") :test #'string=))
+       "x86_64-linux")
+      ((and (string-equal os "Darwin")
+            (member arch '("arm64" "aarch64") :test #'string=))
+       "arm64-darwin")
+      (t
+       (error 'release-archive-error
+              :stage ':prerequisites
+              :cause "Binary releases currently support Linux x86-64 and macOS arm64 only.")))))
+
 (-> release-archive--validate-platform () null)
 (defun release-archive--validate-platform ()
-  "Require the supported Linux x86-64 release target."
-  (unless (and (string-equal (software-type) "Linux")
-               (member (string-downcase (machine-type))
-                       '("x86-64" "x86_64" "amd64")
-                       :test #'string=))
-    (error 'release-archive-error
-           :stage ':prerequisites
-           :cause "Binary releases currently support Linux x86-64 only."))
+  "Require a supported release target platform."
+  (release-archive--platform)
   nil)
+
+(-> release-archive--shared-library-extension () string)
+(defun release-archive--shared-library-extension ()
+  "Return the dynamic library extension for the current platform."
+  (if (string-equal (software-type) "Darwin")
+      "dylib"
+      "so"))
+
+(-> release-archive--checksum-file (pathname pathname) pathname)
+(defun release-archive--checksum-file (file output)
+  "Write the SHA-256 checksum of FILE to OUTPUT."
+  (if (release-archive--command-pathname "sha256sum")
+      (release-archive--run
+       (list "sha256sum" (file-namestring file))
+       :directory (uiop:pathname-directory-pathname file)
+       :output output
+       :error-output ':output)
+      (let* ((output-string
+               (release-archive--run
+                (list "shasum" "-a" "256" (file-namestring file))
+                :directory (uiop:pathname-directory-pathname file)
+                :output ':string
+                :error-output ':output)))
+        (with-open-file (stream output
+                                :direction ':output
+                                :if-exists ':supersede
+                                :if-does-not-exist ':create
+                                :external-format ':utf-8)
+          (write-string output-string stream))))
+  output)
+
+(-> release-archive--tar-command (pathname pathname string string) list)
+(defun release-archive--tar-command (tar-file working-dir release-name commit-time)
+  "Return a tar creation command for TAR-FILE containing RELEASE-NAME below WORKING-DIR."
+  (if (release-archive--command-pathname "gtar")
+      (list "gtar" "--sort=name"
+            (format nil "--mtime=@~A" commit-time)
+            "--owner=0" "--group=0" "--numeric-owner"
+            "-cf" (namestring tar-file)
+            "-C" (namestring working-dir) release-name)
+      (if (string-equal (software-type) "Linux")
+          (list "tar" "--sort=name"
+                (format nil "--mtime=@~A" commit-time)
+                "--owner=0" "--group=0" "--numeric-owner"
+                "-cf" (namestring tar-file)
+                "-C" (namestring working-dir) release-name)
+          (list "tar" "-cf" (namestring tar-file)
+                "-C" (namestring working-dir) release-name))))
 
 (-> release-archive-build
     (&key (:source-root pathname) (:output-directory pathname))
@@ -306,6 +357,11 @@ the managed runtime, matching SBCL source, native libraries, and sandbox helper.
              (output-directory
                (uiop:ensure-directory-pathname
                 (or output-directory (merge-pathnames "dist/" source-root))))
+             (platform (release-archive--platform))
+             (lib-extension (release-archive--shared-library-extension))
+             (fff-library-name (format nil "libfff_c.~A" lib-extension))
+             (colorlisp-library-name
+               (format nil "libcolorlisp-tree-sitter.~A" lib-extension))
              (runtime-version
                (release-archive--trimmed-file
                 (merge-pathnames "sbcl.version" source-root)))
@@ -329,7 +385,8 @@ the managed runtime, matching SBCL source, native libraries, and sandbox helper.
              (fff-library
                (release-archive--environment-pathname
                 "AUTOLITH_RELEASE_FFF_LIBRARY"
-                (merge-pathnames "autolith/native/fff/libfff_c.so" data-home)))
+                (merge-pathnames (format nil "autolith/native/fff/~A" fff-library-name)
+                                 data-home)))
              (colorlisp-library (release-archive--colorlisp-library))
              (sandbox-helper (release-archive--sandbox-helper source-root))
              (version (release-builder--source-version source-root))
@@ -339,7 +396,12 @@ the managed runtime, matching SBCL source, native libraries, and sandbox helper.
                (release-archive--git-output
                 source-root '("show" "-s" "--format=%ct" "HEAD"))))
         (release-archive--require-commands
-         '("chmod" "cp" "find" "git" "gzip" "readlink" "sha256sum" "tar"))
+         '("chmod" "cp" "find" "git" "gzip" "readlink" "tar"))
+        (unless (or (release-archive--command-pathname "sha256sum")
+                    (release-archive--command-pathname "shasum"))
+          (error 'release-archive-error
+                 :stage ':prerequisites
+                 :cause "sha256sum or shasum is required."))
         (release-archive--validate-platform)
         (unless (release-archive--semantic-version-p runtime-version)
           (error 'release-archive-error
@@ -366,10 +428,11 @@ the managed runtime, matching SBCL source, native libraries, and sandbox helper.
           (error 'release-archive-error
                  :stage ':prerequisites
                  :cause "The private ColorLisp library is absent; run ./script/bootstrap."))
-        (unless sandbox-helper
-          (error 'release-archive-error
-                 :stage ':prerequisites
-                 :cause "The private sandbox helper is absent; run ./script/check."))
+        (when (string-equal (software-type) "Linux")
+          (unless sandbox-helper
+            (error 'release-archive-error
+                   :stage ':prerequisites
+                   :cause "The private sandbox helper is absent; run ./script/check.")))
         (unless (release-archive--semantic-version-p version)
           (error 'release-archive-error
                  :stage ':source-validation
@@ -390,7 +453,7 @@ the managed runtime, matching SBCL source, native libraries, and sandbox helper.
                  (release-archive--make-temporary-root output-directory)))
           (unwind-protect
                (let* ((release-name
-                        (format nil "autolith-~A-x86_64-linux" tag))
+                        (format nil "autolith-~A-~A" tag platform))
                       (release-root
                         (merge-pathnames (format nil "~A/" release-name)
                                          temporary-root))
@@ -441,29 +504,34 @@ the managed runtime, matching SBCL source, native libraries, and sandbox helper.
                   runtime-source
                   (merge-pathnames "libexec/sbcl-source" release-root))
                  (release-archive--copy
-                  fff-library (merge-pathnames "lib/libfff_c.so" release-root))
+                  fff-library
+                  (merge-pathnames (format nil "lib/~A" fff-library-name) release-root))
                  (release-archive--copy
                   colorlisp-library
-                  (merge-pathnames "lib/libcolorlisp-tree-sitter.so"
+                  (merge-pathnames (format nil "lib/~A" colorlisp-library-name)
                                    release-root))
-                 (release-archive--copy
-                  sandbox-helper
-                  (merge-pathnames "libexec/cl-exec-sandbox-helper" release-root))
+                 (when sandbox-helper
+                   (release-archive--copy
+                    sandbox-helper
+                    (merge-pathnames "libexec/cl-exec-sandbox-helper" release-root))
+                   (release-archive--run
+                    (list "chmod" "755"
+                          (namestring
+                           (merge-pathnames "libexec/cl-exec-sandbox-helper"
+                                            release-root)))))
                  (release-archive--copy
                   (merge-pathnames "bin/autolith-release" source-root)
                   (merge-pathnames "bin/autolith" release-root))
                  (release-archive--run
                   (list "chmod" "755"
-                        (namestring (merge-pathnames "bin/autolith" release-root))
-                        (namestring
-                         (merge-pathnames "libexec/cl-exec-sandbox-helper"
-                                          release-root))))
+                        (namestring (merge-pathnames "bin/autolith" release-root))))
                  (release-archive--run
                   (list "chmod" "644"
                         (namestring
-                         (merge-pathnames "lib/libfff_c.so" release-root))
+                         (merge-pathnames (format nil "lib/~A" fff-library-name)
+                                          release-root))
                         (namestring
-                         (merge-pathnames "lib/libcolorlisp-tree-sitter.so"
+                         (merge-pathnames (format nil "lib/~A" colorlisp-library-name)
                                           release-root))))
                  (release-archive--write-record
                   (merge-pathnames "RELEASE" release-root)
@@ -500,18 +568,11 @@ the managed runtime, matching SBCL source, native libraries, and sandbox helper.
                  (format t "~&Writing ~A.~%" archive)
                  (finish-output)
                  (release-archive--run
-                  (list "tar" "--sort=name"
-                        (format nil "--mtime=@~A" commit-time)
-                        "--owner=0" "--group=0" "--numeric-owner"
-                        "-cf" (namestring temporary-tar)
-                        "-C" (namestring temporary-root) release-name))
+                  (release-archive--tar-command
+                   temporary-tar temporary-root release-name commit-time))
                  (release-archive--run
                   (list "gzip" "-9n" (namestring temporary-tar)))
-                 (release-archive--run
-                  (list "sha256sum" (file-namestring temporary-archive))
-                  :directory temporary-root
-                  :output temporary-checksum
-                  :error-output ':output)
+                 (release-archive--checksum-file temporary-archive temporary-checksum)
                  (uiop:rename-file-overwriting-target temporary-archive archive)
                  (uiop:rename-file-overwriting-target temporary-checksum checksum)
                  (let ((checksum-value

--- a/server/run
+++ b/server/run
@@ -2,8 +2,30 @@
 
 set -euo pipefail
 
-launcher_path=$(readlink -f -- "${BASH_SOURCE[0]}")
-source_root=$(CDPATH= cd -- "$(dirname -- "$launcher_path")/.." && pwd)
+resolve_path()
+{
+  local path=$1
+  local directory
+  local target
+
+  case "$path" in
+    /*) ;;
+    *) path=$PWD/$path ;;
+  esac
+  while [[ -L "$path" ]]; do
+    directory=$(CDPATH= cd -P "$(dirname "$path")" && pwd) || return 1
+    target=$(readlink "$path") || return 1
+    case "$target" in
+      /*) path=$target ;;
+      *) path=$directory/$target ;;
+    esac
+  done
+  directory=$(CDPATH= cd -P "$(dirname "$path")" && pwd) || return 1
+  printf '%s/%s\n' "$directory" "$(basename "$path")"
+}
+
+launcher_path=$(resolve_path "${BASH_SOURCE[0]}")
+source_root=$(CDPATH= cd -P -- "$(dirname -- "$launcher_path")/.." && pwd)
 
 exec "$source_root/bin/autolith-runtime" \
   --script "$source_root/server/main.lisp" "$@"

--- a/tests/release-script-tests.lisp
+++ b/tests/release-script-tests.lisp
@@ -447,25 +447,99 @@ printf '(:ACTIVE-IMAGE :VERSION 1\\n)\\n' > \"$active/manifest.sexp\"
         (release-script-tests--run
          (list (namestring launcher) "--autolith-release-probe")
          :environment environment
-         :ignore-error-status t
-         :output nil)
-      (declare (ignore output error-output))
-      (test-assert (not (eql status 0))
-                   "the release launcher rejects an inconsistent record"))
+         :ignore-error-status t)
+      (declare (ignore output))
+      (test-assert
+       (and (not (eql status 0))
+            (search "RELEASE has an inconsistent tag." error-output))
+       "the release launcher rejects mismatched RELEASE metadata"))
+    (delete-file (merge-pathnames "RELEASE" release-root)))
+  nil)
+
+(-> release-script-tests--launcher-darwin (pathname pathname) null)
+(defun release-script-tests--launcher-darwin (source-root root)
+  "Exercise Darwin packaged launcher validation and its machine-readable probe."
+  (let* ((release-root
+           (merge-pathnames
+            (format nil "autolith-darwin-launcher-v~A/"
+                    *release-script-tests-version*)
+            root))
+         (launcher
+           (merge-pathnames "bin/autolith" release-root))
+         (host-bin (merge-pathnames "darwin-host-bin/" root))
+         (path (format nil "~A:~A"
+                       (string-right-trim "/" (namestring host-bin))
+                       (or (uiop:getenv "PATH") "")))
+         (environment
+           (list "AUTOLITH_NO_UPDATE_CHECK=1"
+                 (format nil "PATH=~A" path))))
+    (release-script-tests--install-darwin-host-tools host-bin)
+    (release-script-tests--make-release source-root release-root)
+    (let ((output
+            (release-script-tests--run
+             (list (namestring launcher) "--autolith-release-probe")
+             :environment environment)))
+      (dolist (line
+               (list
+                (format nil "version=~A" *release-script-tests-version*)
+                (format nil "tag=v~A" *release-script-tests-version*)
+                (format nil "commit=~A" *release-script-tests-commit*)
+                (format nil "source=~A"
+                        (string-right-trim
+                         "/"
+                         (namestring
+                          (truename
+                           (merge-pathnames "libexec/autolith/" release-root)))))
+                (format nil "runtime=~A"
+                        (namestring
+                         (truename
+                          (merge-pathnames "runtime/bin/sbcl" release-root))))))
+        (test-assert (find line
+                           (uiop:split-string output
+                                              :separator '(#\Newline #\Return))
+                           :test #'string=)
+                     (format nil "Darwin release probe reports ~A" line))))
+    (let ((library
+            (merge-pathnames "lib/libcolorlisp-tree-sitter.dylib"
+                             release-root)))
+      (delete-file library)
+      (multiple-value-bind (output error-output status)
+          (release-script-tests--run
+           (list (namestring launcher) "--autolith-release-probe")
+           :environment environment
+           :ignore-error-status t
+           :output nil)
+        (declare (ignore output error-output))
+        (test-assert (not (eql status 0))
+                     "the Darwin release launcher requires its private syntax library"))
+      (release-script-tests--write-file library ""))
     (release-script-tests--record
      (merge-pathnames "RELEASE" release-root)
-     (format nil "v~A" *release-script-tests-version*)))
+     "v0.12.0")
+    (multiple-value-bind (output error-output status)
+        (release-script-tests--run
+         (list (namestring launcher) "--autolith-release-probe")
+         :environment environment
+         :ignore-error-status t)
+      (declare (ignore output))
+      (test-assert
+       (and (not (eql status 0))
+            (search "RELEASE has an inconsistent tag." error-output))
+       "the Darwin release launcher rejects mismatched RELEASE metadata"))
+    (delete-file (merge-pathnames "RELEASE" release-root)))
   nil)
 
 (-> release-script-tests--installer (pathname pathname) null)
 (defun release-script-tests--installer (source-root root)
-  "Exercise versioned installer publication, repeatability, and latest lookup."
-  (let* ((version *release-script-tests-version*)
-         (tag (format nil "v~A" version))
+  "Exercise binary installer download, verification, link updates, and unsupported platform rejection."
+  (let* ((tag (format nil "v~A" *release-script-tests-version*))
          (next-tag "v0.12.0")
-         (release-name (format nil "autolith-~A-x86_64-linux" tag))
+         (release-name
+           (format nil "autolith-~A-x86_64-linux" tag))
          (release-root
-           (merge-pathnames (format nil "autolith-v~A/" version) root))
+           (merge-pathnames
+            (format nil "autolith-v~A/" *release-script-tests-version*)
+            root))
          (fixture-root (merge-pathnames "fixture/" root))
          (fixture-source (merge-pathnames "fixture-source/" root))
          (fixture-bin (merge-pathnames "fixture-bin/" root))
@@ -492,8 +566,8 @@ printf '(:ACTIVE-IMAGE :VERSION 1\\n)\\n' > \"$active/manifest.sexp\"
        uname
        "#!/bin/sh
 case ${1:-} in
-  -s) printf 'Darwin\\n' ;;
-  -m) printf 'arm64\\n' ;;
+  -s) printf 'FreeBSD\\n' ;;
+  -m) printf 'x86_64\\n' ;;
   *) exit 64 ;;
 esac
 ")
@@ -512,9 +586,9 @@ esac
         (test-assert
          (and (not (eql status 0))
               (search
-               "On macOS, install Autolith with Nix: nix run github:luciusmagn/autolith."
+               "binary releases currently support Linux x86-64 and macOS arm64 only."
                output))
-         "the binary installer directs macOS users to Nix")))
+         "the binary installer rejects unsupported platforms")))
     (release-script-tests--install-linux-host-tools fixture-bin)
     (release-script-tests--run
      (list "cp" "-a" (format nil "~A." (namestring release-root))
@@ -525,10 +599,17 @@ esac
      (list "tar" "-czf" (namestring archive)
            "-C" (namestring fixture-source) release-name)
      :output nil)
-    (release-script-tests--run
-     (list "sha256sum" (file-namestring archive))
-     :directory fixture-root
-     :output checksum)
+    (if (release-archive--command-pathname "sha256sum")
+        (release-script-tests--run
+         (list "sha256sum" (file-namestring archive))
+         :directory fixture-root
+         :output checksum)
+        (let ((output
+                (release-script-tests--run
+                 (list "shasum" "-a" "256" (file-namestring archive))
+                 :directory fixture-root
+                 :output ':string)))
+          (release-script-tests--write-file checksum output)))
     (release-script-tests--write-file
      curl (release-script-tests--fixture-curl))
     (release-script-tests--chmod "755" curl)
@@ -610,6 +691,148 @@ esac
                 base-environment :test #'string=)
         '("AUTOLITH_RELEASE_BASE_URL=https://example.invalid/releases"
           "AUTOLITH_RELEASE_LATEST_URL=https://example.invalid/releases/latest"))
+       :output nil)))
+  nil)
+
+(-> release-script-tests--install-darwin-host-tools (pathname) pathname)
+(defun release-script-tests--install-darwin-host-tools (directory)
+  "Install fixture commands reporting and satisfying the Darwin release target."
+  (let* ((directory (uiop:ensure-directory-pathname directory))
+         (uname (merge-pathnames "uname" directory))
+         (chmod (merge-pathnames "chmod" directory))
+         (move (merge-pathnames "mv" directory)))
+    (release-script-tests--write-file
+     uname
+     "#!/bin/sh
+case ${1:-} in
+  -s) printf 'Darwin\\n' ;;
+  -m) printf 'arm64\\n' ;;
+  *) exit 64 ;;
+esac
+")
+    (release-script-tests--write-file chmod "#!/bin/sh
+recursive=
+if [ \"${1:-}\" = -R ]; then
+  recursive=-R
+  shift
+fi
+mode=$1
+shift
+if [ \"${1:-}\" = -- ]; then
+  shift
+fi
+if [ -n \"$recursive\" ]; then
+  exec /bin/chmod \"$recursive\" \"$mode\" \"$@\"
+else
+  exec /bin/chmod \"$mode\" \"$@\"
+fi
+")
+    (release-script-tests--write-file move "#!/bin/sh
+force=
+if [ \"${1:-}\" = -f ]; then
+  force=-f
+  shift
+fi
+if [ \"${1:-}\" = -- ]; then
+  shift
+fi
+if [ -n \"$force\" ]; then
+  exec /bin/mv -f \"$@\"
+else
+  exec /bin/mv \"$@\"
+fi
+")
+    (dolist (command (list uname chmod move))
+      (release-script-tests--chmod "755" command))
+    directory))
+
+(-> release-script-tests--installer-darwin (pathname pathname) null)
+(defun release-script-tests--installer-darwin (source-root root)
+  "Exercise Darwin arm64 binary installer download, verification, and link updates."
+  (let* ((tag (format nil "v~A" *release-script-tests-version*))
+         (release-name
+           (format nil "autolith-~A-arm64-darwin" tag))
+         (release-root
+           (merge-pathnames
+            (format nil "autolith-darwin-v~A/" *release-script-tests-version*)
+            root))
+         (fixture-root (merge-pathnames "fixture-darwin/" root))
+         (fixture-source (merge-pathnames "fixture-darwin-source/" root))
+         (fixture-bin (merge-pathnames "fixture-darwin-bin/" root))
+         (fixture-release
+           (merge-pathnames (format nil "~A/" release-name) fixture-source))
+         (archive
+           (merge-pathnames (format nil "~A.tar.gz" release-name) fixture-root))
+         (checksum
+           (merge-pathnames (format nil "~A.tar.gz.sha256" release-name)
+                            fixture-root))
+         (install-root (merge-pathnames "darwin-installation/" root))
+         (bin-directory (merge-pathnames "darwin-bin/" root))
+         (curl (merge-pathnames "curl" fixture-bin))
+         (installer (merge-pathnames "script/install" source-root)))
+    (release-script-tests--make-release source-root release-root)
+    (uiop:ensure-all-directories-exist
+     (list fixture-root fixture-source fixture-bin fixture-release))
+    (release-script-tests--install-darwin-host-tools fixture-bin)
+    (release-script-tests--run
+     (list "cp" "-a" (format nil "~A." (namestring release-root))
+           (namestring fixture-release))
+     :output nil)
+    (release-script-tests--chmod "a-w" fixture-release)
+    (release-script-tests--run
+     (list "tar" "-czf" (namestring archive)
+           "-C" (namestring fixture-source) release-name)
+     :output nil)
+    (if (release-archive--command-pathname "sha256sum")
+        (release-script-tests--run
+         (list "sha256sum" (file-namestring archive))
+         :directory fixture-root
+         :output checksum)
+        (let ((output
+                (release-script-tests--run
+                 (list "shasum" "-a" "256" (file-namestring archive))
+                 :directory fixture-root
+                 :output ':string)))
+          (release-script-tests--write-file checksum output)))
+    (release-script-tests--write-file
+     curl (release-script-tests--fixture-curl))
+    (release-script-tests--chmod "755" curl)
+    (let* ((path (format nil "~A:~A"
+                         (string-right-trim "/" (namestring fixture-bin))
+                         (or (uiop:getenv "PATH") "")))
+           (base-environment
+             (list
+              (format nil "PATH=~A" path)
+              (format nil "AUTOLITH_TEST_RELEASE_FIXTURE=~A"
+                      (namestring fixture-root))
+              "AUTOLITH_RELEASE_BASE_URL=https://example.invalid"
+              (format nil "AUTOLITH_INSTALL_ROOT=~A"
+                      (string-right-trim "/" (namestring install-root)))
+              (format nil "AUTOLITH_BIN_DIR=~A"
+                      (string-right-trim "/" (namestring bin-directory))))))
+      (release-script-tests--run
+       (list (namestring installer) "--version" tag)
+       :environment base-environment
+       :output nil)
+      (test-assert
+       (probe-file
+        (merge-pathnames (format nil "releases/~A/bin/autolith" tag)
+                         install-root))
+       "the Darwin installer publishes the requested release")
+      (test-assert
+       (string= (release-script-tests--readlink
+                 (merge-pathnames "current" install-root))
+                (format nil "releases/~A" tag))
+       "the Darwin installer selects the requested version atomically")
+      (test-assert
+       (string= (release-script-tests--readlink
+                 (merge-pathnames "autolith" bin-directory))
+                (namestring (merge-pathnames "current/bin/autolith"
+                                             install-root)))
+       "the Darwin installer publishes the user command link")
+      (release-script-tests--run
+       (list (namestring installer) "--version" tag)
+       :environment base-environment
        :output nil)))
   nil)
 
@@ -987,7 +1210,9 @@ esac
            (release-script-tests--runtime-adapter source-root root)
            (release-script-tests--source-launcher source-root root)
            (release-script-tests--launcher source-root root)
+           (release-script-tests--launcher-darwin source-root root)
            (release-script-tests--update-handoff source-root root)
-           (release-script-tests--installer source-root root))
+           (release-script-tests--installer source-root root)
+           (release-script-tests--installer-darwin source-root root))
       (release-script-tests--cleanup root)))
   nil)


### PR DESCRIPTION

extends the existing Linux x86-64 standalone binary release pipeline to produce and install `arm64-darwin` archives
## changes

- detect Darwin arm64 in `bin/autolith-release`, `script/install`, and `server/release-archive.lisp`; bundle `.dylib` libraries and skip linux-only `bwrap`/`cl-exec-sandbox-helper`
- add `sbcl-2.4.0-arm64-darwin` bootstrap hash to `script/build-release-runtime.lisp`
- add `package-macos-arm64` CI job (`macos-14` runner) to `release.yml`
- replace non-portable GNU-isms (`readlink -f`, `chmod --`, `command -v`) with POSIX/CL-native equivalents
- use `truename`/`probe-file` instead of shelling out to `readlink` in the release packager
- add darwin launcher and installer test fixtures
- align `flake.nix` version assertions with Clingon output format

## local checks performed:

- `nix flake check` passes all derivations and tests
- tagged release (`v0.32.2`) built on GH actions, downloaded and installed on local macOS arm64 host( mba m5 ); cli runs correctly