### PR TITLE
Fix #35

### DIFF
--- a/tests/openai-compatible-provider-tests.lisp
+++ b/tests/openai-compatible-provider-tests.lisp
@@ -241,7 +241,9 @@
                            :model model
                            :reasoning-effort "minimal"))
            (let ((authenticated-configuration nil)
-                 (authenticated-selection :unset))
+                 (authenticated-selection :unset)
+                 (live-application (make-instance 'application))
+                 (reconnect-called-p nil))
              (test-call-with-function-replacements
               (list
                (list 'configuration-create
@@ -275,14 +277,24 @@
                        (setf authenticated-configuration configuration
                              authenticated-selection selection)
                        nil))
+               (list 'application-reconnect
+                     (lambda (application &rest arguments)
+                       (declare (ignore arguments))
+                       (setf reconnect-called-p t)
+                       application))
                ;; Authentication continues into a session; a real interactive
                ;; loop against the test's non-terminal stdin can wait forever.
                (list 'application-run
                      (lambda (application &rest arguments)
                        (declare (ignore application arguments))
                        nil)))
-              (lambda ()
-                (main-dispatch '("auth"))))
+               (lambda ()
+                 (let ((*active-application* live-application))
+                   (let ((*active-application* nil))
+                     (main-dispatch '("auth"))))))
+             (test-assert
+              (not reconnect-called-p)
+              "bare auth does not reconnect the active application")
              (test-assert
               (and authenticated-configuration
                    (null authenticated-selection)


### PR DESCRIPTION
This PR fixes issue #35.  I've tested this myself extensively, and it
certainly fixes the `self.commit` issue.

One could argue that maybe `self.commit`'s test suite execution should
construct a new autolith worker and testing on it specifically, but
then again I'm not certain about how the tests work and whether they
have particulars that require working on the _current_ test session.