### PR TITLE
Parallel tool calls, fast mode, and standard responses api

### DIFF
--- a/docs/guide.org
+++ b/docs/guide.org
@@ -280,6 +280,12 @@ models keep the preference but use the standard path. Set
 =AUTOLITH_CODEX_FAST_MODE=on= or =off= to override the saved choice for one
 process; while it is set, =/fast on= and =/fast off= are unavailable.
 
+ChatGPT Codex uses standard Responses requests and native Responses compaction.
+Normal requests enable provider parallel tool calls. Autolith executes independent
+calls concurrently, then records their results in provider wire order. Calls
+requiring a provider round trip, exclusive tools, and calls sharing one mutable
+runtime execute in separate ordered waves.
+
 #+BEGIN_SRC sh
 autolith auth nous
 #+END_SRC

--- a/docs/guide.org
+++ b/docs/guide.org
@@ -271,6 +271,12 @@ Built-in ChatGPT, Grok, and Nous Research subscriptions authenticate through a
 browser device flow. Anthropic, Fireworks, OpenCode, Mistral, and user-registered
 OpenAI-compatible providers use API keys.
 
+ChatGPT Codex Fast mode sends =service_tier=fast= on provider requests and uses
+2x plan usage. Use =/fast= or =/fast status= to inspect it, and =/fast on= or
+=/fast off= to change it. The choice persists across restarts. Set
+=AUTOLITH_CODEX_FAST_MODE=on= or =off= to override the saved choice for one
+process.
+
 #+BEGIN_SRC sh
 autolith auth nous
 #+END_SRC

--- a/docs/guide.org
+++ b/docs/guide.org
@@ -271,11 +271,13 @@ Built-in ChatGPT, Grok, and Nous Research subscriptions authenticate through a
 browser device flow. Anthropic, Fireworks, OpenCode, Mistral, and user-registered
 OpenAI-compatible providers use API keys.
 
-ChatGPT Codex Fast mode sends =service_tier=fast= on provider requests and uses
-2x plan usage. Use =/fast= or =/fast status= to inspect it, and =/fast on= or
-=/fast off= to change it. The choice persists across restarts. Set
+ChatGPT Codex Fast mode sends =service_tier=fast= when the active Codex model
+advertises Fast support and uses 2x plan usage. The built-in GPT-5.6 models
+support it. Use =/fast= or =/fast status= to inspect it, and =/fast on= or
+=/fast off= to change the saved preference. Other providers and unknown Codex
+models keep the preference but use the standard path. Set
 =AUTOLITH_CODEX_FAST_MODE=on= or =off= to override the saved choice for one
-process.
+process; while it is set, =/fast on= and =/fast off= are unavailable.
 
 #+BEGIN_SRC sh
 autolith auth nous

--- a/docs/guide.org
+++ b/docs/guide.org
@@ -271,7 +271,7 @@ Built-in ChatGPT, Grok, and Nous Research subscriptions authenticate through a
 browser device flow. Anthropic, Fireworks, OpenCode, Mistral, and user-registered
 OpenAI-compatible providers use API keys.
 
-ChatGPT Codex Fast mode sends =service_tier=fast= when the active Codex model
+ChatGPT Codex Fast mode sends =service_tier=priority= when the active Codex model
 advertises Fast support and uses 2x plan usage. The built-in GPT-5.6 models
 support it. Use =/fast= or =/fast status= to inspect it, and =/fast on= or
 =/fast off= to change the saved preference. Other providers and unknown Codex

--- a/docs/guide.org
+++ b/docs/guide.org
@@ -274,7 +274,8 @@ OpenAI-compatible providers use API keys.
 ChatGPT Codex Fast mode sends =service_tier=priority= when the active Codex model
 advertises Fast support and uses 2x plan usage. The built-in GPT-5.6 models
 support it. Use =/fast= or =/fast status= to inspect it, and =/fast on= or
-=/fast off= to change the saved preference. Other providers and unknown Codex
+=/fast off= to change the saved preference. The activity status line displays
+=FAST= while the active model uses Fast mode. Other providers and unknown Codex
 models keep the preference but use the standard path. Set
 =AUTOLITH_CODEX_FAST_MODE=on= or =off= to override the saved choice for one
 process; while it is set, =/fast on= and =/fast off= are unavailable.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -34,8 +34,8 @@ let
     src = pkgs.fetchFromGitHub {
       owner = "lambda-symbolics";
       repo = "cl-llm-provider-api";
-      rev = "ee1eb5bfdc92e62ec63f834dfff419b760cabf9d";
-      hash = "sha256-8GDbbu/WMrv5Ugl2HnVnqBrxVAjEsbIN4AbOMC/Iwwk=";
+      rev = "af49d9d99fbf82ed0d91fa7c352cc2489845b015";
+      hash = "sha256-2ayWg2QKXvr44epQLvQJmf3ArMv7LsGhWOZZMFRI0Mg=";
     };
     lispLibs = with pkgs.sbclPackages; [
       babel

--- a/qlfile
+++ b/qlfile
@@ -14,7 +14,7 @@ ql yason 2026-01-01
 git cl-colorist https://github.com/luciusmagn/cl-colorist.git :ref a4b65e63f40248c091d8ccf6023ad6fef5de7f0d
 git clinedi https://github.com/luciusmagn/clinedi.git :ref de133d8467ed211369923285078cbfa456e1d92b
 git cl-jobpond https://github.com/luciusmagn/cl-jobpond.git :ref ee2e2eb0bd5080c52db55036f853c00671962178
-git cl-llm-provider-api https://github.com/lambda-symbolics/cl-llm-provider-api.git :ref ee1eb5bfdc92e62ec63f834dfff419b760cabf9d
+git cl-llm-provider-api https://github.com/lambda-symbolics/cl-llm-provider-api.git :ref af49d9d99fbf82ed0d91fa7c352cc2489845b015
 git cl-skills https://github.com/lambda-symbolics/cl-skills.git :ref a34b85a3aabca9530c5f9772ea988a6399a57963
 git cl-termdown https://github.com/lambda-symbolics/cl-termdown.git :ref 340579ac634074791e9c2cc3c35323fec3b7cf66
 git cl-exec-sandbox https://github.com/lambda-symbolics/cl-exec-sandbox.git :ref 9af411ec2779efc06a7c56996babdd931d77e371

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -64,8 +64,8 @@
   :version "git-ee2e2eb0bd5080c52db55036f853c00671962178"))
 ("cl-llm-provider-api" .
  (:class qlot/source/git:source-git
-  :initargs (:remote-url "https://github.com/lambda-symbolics/cl-llm-provider-api.git" :ref "ee1eb5bfdc92e62ec63f834dfff419b760cabf9d")
-  :version "git-ee1eb5bfdc92e62ec63f834dfff419b760cabf9d"))
+  :initargs (:remote-url "https://github.com/lambda-symbolics/cl-llm-provider-api.git" :ref "af49d9d99fbf82ed0d91fa7c352cc2489845b015")
+  :version "git-af49d9d99fbf82ed0d91fa7c352cc2489845b015"))
 ("cl-skills" .
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/lambda-symbolics/cl-skills.git" :ref "a34b85a3aabca9530c5f9772ea988a6399a57963")

--- a/src/agent/runtime.lisp
+++ b/src/agent/runtime.lisp
@@ -59,6 +59,19 @@
     :documentation "The optional function authorizing one external tool call."))
   (:documentation "An agent observer implemented by ordinary terminal-facing callbacks."))
 
+(defclass serialized-agent-observer (agent-observer)
+  ((delegate
+    :initarg :delegate
+    :reader serialized-agent-observer-delegate
+    :type agent-observer
+    :documentation "The observer receiving callbacks under the serialization lock.")
+   (lock
+    :initform (make-recursive-lock "Autolith agent observer callbacks")
+    :reader serialized-agent-observer-lock
+    :documentation "The recursive lock serializing callbacks from tool workers."))
+  (:documentation
+   "An observer wrapper serializing callbacks made by concurrent tool workers."))
+
 (defclass agent-steering-input ()
   ((identifier
     :initarg :identifier
@@ -112,6 +125,9 @@
 
 (defparameter *agent-restricted-maximum-tool-rounds* 4
   "Maximum executed tool rounds within one restricted agent turn.")
+
+(defparameter *agent-maximum-concurrent-tool-workers* 8
+  "Maximum worker threads executing independent calls from one provider batch.")
 
 
 ;;;; -- Agent Conditions --
@@ -289,6 +305,67 @@
     (if callback
         (funcall callback tool arguments)
         ':deny)))
+
+(defmethod agent-observer-text
+    ((observer serialized-agent-observer) (text string))
+  "Forward assistant TEXT to OBSERVER's delegate under its callback lock."
+  (with-recursive-lock-held ((serialized-agent-observer-lock observer))
+    (agent-observer-text (serialized-agent-observer-delegate observer) text)))
+
+(defmethod agent-observer-reasoning
+    ((observer serialized-agent-observer) (text string))
+  "Forward reasoning TEXT to OBSERVER's delegate under its callback lock."
+  (with-recursive-lock-held ((serialized-agent-observer-lock observer))
+    (agent-observer-reasoning
+     (serialized-agent-observer-delegate observer) text)))
+
+(defmethod agent-observer-status
+    ((observer serialized-agent-observer) status details)
+  "Forward STATUS and DETAILS to OBSERVER's delegate under its callback lock."
+  (declare (type keyword status)
+           (type list details))
+  (with-recursive-lock-held ((serialized-agent-observer-lock observer))
+    (agent-observer-status
+     (serialized-agent-observer-delegate observer) status details)))
+
+(defmethod agent-observer-take-steering
+    ((observer serialized-agent-observer))
+  "Drain steering from OBSERVER's delegate under its callback lock."
+  (with-recursive-lock-held ((serialized-agent-observer-lock observer))
+    (agent-observer-take-steering
+     (serialized-agent-observer-delegate observer))))
+
+(defmethod agent-observer-steering-persisted
+    ((observer serialized-agent-observer) (identifier string))
+  "Forward durable steering IDENTIFIER under OBSERVER's callback lock."
+  (with-recursive-lock-held ((serialized-agent-observer-lock observer))
+    (agent-observer-steering-persisted
+     (serialized-agent-observer-delegate observer) identifier)))
+
+(defmethod agent-observer-apply-pending-operations
+    ((observer serialized-agent-observer) agent)
+  "Apply queued operations through OBSERVER's delegate under its callback lock."
+  (with-recursive-lock-held ((serialized-agent-observer-lock observer))
+    (agent-observer-apply-pending-operations
+     (serialized-agent-observer-delegate observer) agent)))
+
+(defmethod agent-observer-authorize-command
+    ((observer serialized-agent-observer)
+     (command string)
+     (directory pathname))
+  "Authorize COMMAND through OBSERVER's delegate under its callback lock."
+  (with-recursive-lock-held ((serialized-agent-observer-lock observer))
+    (agent-observer-authorize-command
+     (serialized-agent-observer-delegate observer) command directory)))
+
+(defmethod agent-observer-authorize-tool
+    ((observer serialized-agent-observer)
+     (tool tool)
+     (arguments hash-table))
+  "Authorize TOOL through OBSERVER's delegate under its callback lock."
+  (with-recursive-lock-held ((serialized-agent-observer-lock observer))
+    (agent-observer-authorize-tool
+     (serialized-agent-observer-delegate observer) tool arguments)))
 
 
 ;;;; -- Construction and Turn Entry --
@@ -699,6 +776,174 @@
              :output message))))
   nil)
 
+(-> agent--execute-tool-plan
+    (agent list agent-observer boolean boolean)
+    list)
+(defun agent--execute-tool-plan
+    (agent plan observer tool-restriction-p record-timings-p)
+  "Execute one PLAN body and return its result, timings, or fatal condition."
+  (let* ((call      (getf plan :call))
+         (call-id   (json-get call "call_id"))
+         (context
+           (make-instance
+            'tool-context
+            :configuration (agent-configuration agent)
+            :worker (agent-worker agent)
+            :conversation (agent-conversation agent)
+            :registry (agent-tool-registry agent)
+            :agent agent
+            :observer observer
+            :call-id call-id
+            :command-authorization-function
+            (lambda (command directory)
+              (agent-observer-authorize-command observer command directory))
+            :tool-authorization-function
+            (lambda (tool arguments)
+              (agent-observer-authorize-tool observer tool arguments))))
+         (*workspace-tool-readable-roots*
+           (and tool-restriction-p
+                (list
+                 (configuration-working-directory
+                  (agent-configuration agent))
+                 (configuration-source-root
+                  (agent-configuration agent)))))
+         (*resource-readable-schemes*
+           (and tool-restriction-p '("workspace")))
+         (real-start (get-internal-real-time))
+         (cpu-start  (get-internal-run-time))
+         (result nil)
+         (condition nil))
+    (handler-case
+        (setf result
+              (tool-registry-execute-call
+               (agent-tool-registry agent)
+               call
+               context))
+      (serious-condition (failure)
+        (setf condition failure)))
+    (list
+     :plan plan
+     :result result
+     :condition condition
+     :cpu-microseconds
+     (and record-timings-p
+          (round (* (- (get-internal-run-time) cpu-start) 1000000)
+                 internal-time-units-per-second))
+     :real-microseconds
+     (and record-timings-p
+          (round (* (- (get-internal-real-time) real-start) 1000000)
+                 internal-time-units-per-second)))))
+
+(-> agent--complete-tool-executions
+    (agent list agent-observer integer)
+    null)
+(defun agent--complete-tool-executions
+    (agent executions observer tool-round)
+  "Persist EXECUTIONS and report completions in provider wire order."
+  (dolist (execution executions)
+    (let* ((plan      (getf execution :plan))
+           (call      (getf plan :call))
+           (call-id   (json-get call "call_id"))
+           (tool-name (function-call-canonical-name call))
+           (result    (getf execution :result)))
+      (when result
+        (conversation-append-tool-result
+         (agent-conversation agent)
+         call-id
+         :tool-name tool-name
+         :output (tool-result-content result)
+         :content-blocks (tool-result-content-blocks result)
+         :success-p (tool-result-success-p result)
+         :cpu-microseconds (getf execution :cpu-microseconds)
+         :real-microseconds (getf execution :real-microseconds)
+         :persistence (getf plan :persistence))
+        (agent-observer-status
+         observer
+         :tool-call-completed
+         (list :tool-round tool-round
+               :call-id call-id
+               :tool tool-name
+               :success-p (tool-result-success-p result)
+               :cpu-microseconds (getf execution :cpu-microseconds)
+               :real-microseconds (getf execution :real-microseconds)
+               :output (tool-result-content result)
+               :details (tool-result-details result))))))
+  (let ((failure
+          (find-if (lambda (execution)
+                     (getf execution :condition))
+                   executions)))
+    (when failure
+      (error (getf failure :condition))))
+  nil)
+
+(-> agent--run-tool-wave
+    (agent list agent-observer integer boolean)
+    null)
+(defun agent--run-tool-wave
+    (agent plans observer tool-round tool-restriction-p)
+  "Execute independent PLANS concurrently and complete them in wire order."
+  (dolist (plan plans)
+    (let ((call (getf plan :call)))
+      (agent-observer-status
+       observer
+       :tool-call-started
+       (list :tool-round tool-round
+             :call-id (json-get call "call_id")
+             :tool (function-call-canonical-name call)))))
+  (let* ((count (length plans))
+         (executions (make-array count))
+         (record-timings-p (= count 1)))
+    (if (= count 1)
+        (setf (aref executions 0)
+              (agent--execute-tool-plan
+               agent (first plans) observer tool-restriction-p t))
+        (let ((next-index 0)
+              (claim-lock (make-lock "Autolith tool wave claims"))
+              (threads nil)
+              (thread-creation-condition nil))
+          (flet ((work ()
+                   (loop
+                     (let ((index
+                             (with-lock-held (claim-lock)
+                               (when (< next-index count)
+                                 (prog1 next-index
+                                   (incf next-index))))))
+                       (unless index
+                         (return))
+                       (setf (aref executions index)
+                             (agent--execute-tool-plan
+                              agent
+                              (nth index plans)
+                              observer
+                              tool-restriction-p
+                              record-timings-p))))))
+            (unwind-protect
+                 (progn
+                   (loop repeat
+                           (min count *agent-maximum-concurrent-tool-workers*)
+                         while (null thread-creation-condition)
+                         do
+                           (handler-case
+                               (push
+                                (make-thread #'work :name "autolith-tool-call")
+                                threads)
+                             (serious-condition (condition)
+                               (setf thread-creation-condition condition))))
+                   (when thread-creation-condition
+                     (work))
+                   (mapc #'join-thread threads))
+              (mapc (lambda (thread)
+                      (when (thread-alive-p thread)
+                        (ignore-errors (join-thread thread))))
+                    threads))
+            (when thread-creation-condition
+              (agent--complete-tool-executions
+               agent (coerce executions 'list) observer tool-round)
+              (error thread-creation-condition)))))
+    (agent--complete-tool-executions
+     agent (coerce executions 'list) observer tool-round))
+  nil)
+
 (-> agent--execute-tool-calls
     (agent list provider-result
      &key (:observer agent-observer) (:tool-round integer)
@@ -707,109 +952,73 @@
 (defun agent--execute-tool-calls
     (agent call-plans provider-result
      &key observer tool-round tool-allowlist (tool-restriction-p nil))
-  "Execute planned calls sequentially, respecting terminal and barrier states."
-  (loop for remaining on call-plans
-        for plan = (first remaining)
-        for call = (getf plan :call)
-        do
-          (when (getf plan :blocked-p)
-            (agent--reject-tool-call-plans
-             agent
-             remaining
-             observer
-             :tool-round tool-round
-             :message
-             "This call was not executed because a preceding tool requires a provider round trip. Retry it after inspecting that tool's result and the refreshed instructions.")
-            (return))
-          (when (and tool-restriction-p
-                     (not (agent--tool-call-allowed-p call tool-allowlist)))
-            (error 'agent-loop-error
+  "Execute planned calls in independent waves while respecting barriers."
+  (let ((serialized-observer
+          (make-instance 'serialized-agent-observer :delegate observer))
+        (wave nil)
+        (wave-keys (make-hash-table :test #'eql)))
+    (labels ((flush-wave ()
+               (when wave
+                 (agent--run-tool-wave
+                  agent
+                  (nreverse wave)
+                  serialized-observer
+                  tool-round
+                  tool-restriction-p)
+                 (setf wave nil)
+                 (clrhash wave-keys))))
+      (loop for remaining on call-plans
+            for plan = (first remaining)
+            for call = (getf plan :call)
+            for tool = (getf plan :tool)
+            for barrier-p = (and tool
+                                 (tool-provider-round-trip-barrier-p tool))
+            for exclusive-p = (or barrier-p
+                                  (and tool
+                                       (eq (tool-execution-policy tool)
+                                           ':exclusive)))
+            for key = (and tool (tool-concurrency-key tool))
+            do
+              (when (getf plan :blocked-p)
+                (flush-wave)
+                (agent--reject-tool-call-plans
+                 agent
+                 remaining
+                 serialized-observer
+                 :tool-round tool-round
+                 :message
+                 "This call was not executed because a preceding tool requires a provider round trip. Retry it after inspecting that tool's result and the refreshed instructions.")
+                (return))
+              (when (and tool-restriction-p
+                         (not (agent--tool-call-allowed-p call tool-allowlist)))
+                (error 'agent-loop-error
+                       :message
+                       (format nil
+                               "Tool ~A is unavailable during this restricted turn."
+                               (function-call-canonical-name call))
+                       :conversation-id
+                       (conversation-identifier (agent-conversation agent))
+                       :request-number nil))
+              (when (or exclusive-p
+                        (and key (gethash key wave-keys)))
+                (flush-wave))
+              (push plan wave)
+              (when key
+                (setf (gethash key wave-keys) t))
+              (when exclusive-p
+                (flush-wave))
+              (when (agent-turn-complete-p agent provider-result)
+                (flush-wave)
+                (when (rest remaining)
+                  (agent--reject-tool-call-plans
+                   agent
+                   (rest remaining)
+                   serialized-observer
+                   :tool-round tool-round
                    :message
-                   (format nil
-                           "Tool ~A is unavailable during this restricted turn."
-                           (function-call-canonical-name call))
-                   :conversation-id
-                   (conversation-identifier (agent-conversation agent))
-                   :request-number nil))
-          (let* ((call-id   (json-get call "call_id"))
-                 (tool-name (function-call-canonical-name call))
-                 (context
-                   (make-instance
-                    'tool-context
-                    :configuration (agent-configuration agent)
-                    :worker (agent-worker agent)
-                    :conversation (agent-conversation agent)
-                    :registry (agent-tool-registry agent)
-                    :agent agent
-                    :observer observer
-                    :call-id call-id
-                    :command-authorization-function
-                    (lambda (command directory)
-                      (agent-observer-authorize-command
-                       observer command directory))
-                    :tool-authorization-function
-                    (lambda (tool arguments)
-                      (agent-observer-authorize-tool
-                       observer tool arguments)))))
-            (agent-observer-status
-             observer
-             :tool-call-started
-             (list :tool-round tool-round
-                   :call-id call-id
-                   :tool tool-name))
-            (let* ((*workspace-tool-readable-roots*
-                     (and tool-restriction-p
-                          (list
-                           (configuration-working-directory
-                            (agent-configuration agent))
-                           (configuration-source-root
-                            (agent-configuration agent)))))
-                   (*resource-readable-schemes*
-                     (and tool-restriction-p '("workspace")))
-                   (real-start (get-internal-real-time))
-                   (cpu-start  (get-internal-run-time))
-                   (result
-                     (tool-registry-execute-call
-                      (agent-tool-registry agent)
-                      call
-                      context))
-                   (cpu-microseconds
-                     (round (* (- (get-internal-run-time) cpu-start) 1000000)
-                            internal-time-units-per-second))
-                   (real-microseconds
-                     (round (* (- (get-internal-real-time) real-start) 1000000)
-                            internal-time-units-per-second)))
-              (conversation-append-tool-result
-               (agent-conversation agent)
-               call-id
-               :tool-name tool-name
-               :output (tool-result-content result)
-               :content-blocks (tool-result-content-blocks result)
-               :success-p (tool-result-success-p result)
-               :cpu-microseconds cpu-microseconds
-               :real-microseconds real-microseconds
-               :persistence (getf plan :persistence))
-              (agent-observer-status
-               observer
-               :tool-call-completed
-               (list :tool-round tool-round
-                     :call-id call-id
-                     :tool tool-name
-                     :success-p (tool-result-success-p result)
-                     :cpu-microseconds cpu-microseconds
-                     :real-microseconds real-microseconds
-                     :output (tool-result-content result)
-                     :details (tool-result-details result)))))
-        (when (agent-turn-complete-p agent provider-result)
-          (when (rest remaining)
-            (agent--reject-tool-call-plans
-             agent
-             (rest remaining)
-             observer
-             :tool-round tool-round
-             :message
-             "This call was not executed because the agent turn already completed."))
-          (return)))
+                   "This call was not executed because the agent turn already completed."))
+                (return))
+            finally (flush-wave))))
   nil)
 
 (-> agent--apply-steering-input (agent agent-observer integer) null)

--- a/src/application/commands.lisp
+++ b/src/application/commands.lisp
@@ -2181,7 +2181,7 @@ are forwarded to TERMINAL-UI-SELECT."
     (:name "/fast"
      :argument "[on|off|status]"
      :description "show or change Codex Fast mode"
-     :tip "uses service_tier=fast at 2x plan usage for future Codex requests."
+     :tip "uses service_tier=priority at 2x plan usage for future Codex requests."
      :busy-behavior :apply
      :terminal-behavior :shared
      :call-lambda-list (&optional mode)

--- a/src/application/commands.lisp
+++ b/src/application/commands.lisp
@@ -278,9 +278,14 @@
      (application--field-spans "effort"
                                (configuration-reasoning-effort configuration))
      (application--field-spans
-       "Codex fast"
-       (application--toggle-state
-        (configuration-codex-fast-mode-p configuration)))
+      "Codex fast"
+      (cond
+        ((configuration-codex-fast-mode-active-p configuration)
+         "on")
+        ((configuration-codex-fast-mode-p configuration)
+         "on (saved; inactive)")
+        (t
+         "off")))
      (application--field-spans "web search"
                                (configuration-web-search-mode configuration))
      (application--field-spans
@@ -342,11 +347,10 @@
                                       configuration)))
                                    ""))
      (application--field-spans
-       "path"
-       (if (and (eq (model-family (configuration-model configuration)) ':codex)
-                (configuration-codex-fast-mode-p configuration))
-           "fast (2x Codex plan usage)"
-           "standard"))
+      "path"
+      (if (configuration-codex-fast-mode-active-p configuration)
+          "fast (2x Codex plan usage)"
+          "standard"))
      (application--field-spans "web search"
                                (configuration-web-search-mode configuration))
      (application--field-spans "goal"
@@ -618,9 +622,21 @@
     (application--persist-model-selection application configuration)
     (application--install-configuration application configuration)))
 
+(-> application--codex-fast-mode-environment-p () boolean)
+(defun application--codex-fast-mode-environment-p ()
+  "Return true when the process environment controls Codex Fast mode."
+  (not (null (non-empty-string-p
+              (uiop:getenv "AUTOLITH_CODEX_FAST_MODE")))))
+
 (-> application-set-codex-fast-mode (application boolean) null)
 (defun application-set-codex-fast-mode (application enabled-p)
   "Persist and apply Codex Fast mode for future provider requests."
+  (when (application--codex-fast-mode-environment-p)
+    (error 'configuration-error
+           :message
+           (format nil
+                   "AUTOLITH_CODEX_FAST_MODE controls Fast mode for this ~
+                    process; unset it before using /fast on or /fast off.")))
   (let ((configuration
           (configuration-with-codex-fast-mode
            (application-configuration application)
@@ -637,19 +653,38 @@
   "Set or report APPLICATION's persisted Codex Fast mode."
   (let* ((configuration (application-configuration application))
          (mode (and argument (string-downcase argument)))
-         (enabled-p (configuration-codex-fast-mode-p configuration)))
+         (enabled-p (configuration-codex-fast-mode-p configuration))
+         (available-p
+           (configuration-codex-fast-mode-available-p configuration)))
     (cond
       ((or (null mode) (string= mode "status"))
        (application-present
         application
-        (format nil
-                "Codex Fast mode is ~A. This setting persists across restarts."
-                (if enabled-p "on" "off"))))
+        (cond
+          ((application--codex-fast-mode-environment-p)
+           (format nil
+                   "Codex Fast mode is ~A for this process. ~
+                    AUTOLITH_CODEX_FAST_MODE controls it.~:[ The current ~
+                    model uses the standard path.~;~]"
+                   (if enabled-p "on" "off")
+                   available-p))
+          (available-p
+           (format nil
+                   "Codex Fast mode is ~A. This setting persists across restarts."
+                   (if enabled-p "on" "off")))
+          (t
+           (format nil
+                   "Codex Fast mode preference is ~A. The current model uses the standard path."
+                   (if enabled-p "on" "off"))))))
       ((string= mode "on")
        (application-set-codex-fast-mode application t)
        (application-present
         application
-        "Codex Fast mode is enabled and saved. It uses 2x plan usage."))
+        (if available-p
+            "Codex Fast mode is enabled and saved. It uses 2x plan usage."
+            (format nil
+                    "Codex Fast mode preference is enabled and saved. ~
+                     The current model uses the standard path."))))
       ((string= mode "off")
        (application-set-codex-fast-mode application nil)
        (application-present application "Codex Fast mode is disabled and saved."))

--- a/src/application/commands.lisp
+++ b/src/application/commands.lisp
@@ -277,6 +277,10 @@
                                (configuration-model configuration))
      (application--field-spans "effort"
                                (configuration-reasoning-effort configuration))
+     (application--field-spans
+       "Codex fast"
+       (application--toggle-state
+        (configuration-codex-fast-mode-p configuration)))
      (application--field-spans "web search"
                                (configuration-web-search-mode configuration))
      (application--field-spans
@@ -337,8 +341,12 @@
                                      (configuration-working-directory
                                       configuration)))
                                    ""))
-     (application--field-spans "path"
-                               "standard (the fast path is never requested)")
+     (application--field-spans
+       "path"
+       (if (and (eq (model-family (configuration-model configuration)) ':codex)
+                (configuration-codex-fast-mode-p configuration))
+           "fast (2x Codex plan usage)"
+           "standard"))
      (application--field-spans "web search"
                                (configuration-web-search-mode configuration))
      (application--field-spans "goal"
@@ -609,6 +617,46 @@
            effort)))
     (application--persist-model-selection application configuration)
     (application--install-configuration application configuration)))
+
+(-> application-set-codex-fast-mode (application boolean) null)
+(defun application-set-codex-fast-mode (application enabled-p)
+  "Persist and apply Codex Fast mode for future provider requests."
+  (let ((configuration
+          (configuration-with-codex-fast-mode
+           (application-configuration application)
+           enabled-p)))
+    (preferences-set-codex-fast-mode configuration enabled-p)
+    (application--install-configuration application configuration)
+    (application-publish-recovery-session application))
+  nil)
+
+(-> application-codex-fast-mode-command
+    (application (option string))
+    null)
+(defun application-codex-fast-mode-command (application argument)
+  "Set or report APPLICATION's persisted Codex Fast mode."
+  (let* ((configuration (application-configuration application))
+         (mode (and argument (string-downcase argument)))
+         (enabled-p (configuration-codex-fast-mode-p configuration)))
+    (cond
+      ((or (null mode) (string= mode "status"))
+       (application-present
+        application
+        (format nil
+                "Codex Fast mode is ~A. This setting persists across restarts."
+                (if enabled-p "on" "off"))))
+      ((string= mode "on")
+       (application-set-codex-fast-mode application t)
+       (application-present
+        application
+        "Codex Fast mode is enabled and saved. It uses 2x plan usage."))
+      ((string= mode "off")
+       (application-set-codex-fast-mode application nil)
+       (application-present application "Codex Fast mode is disabled and saved."))
+      (t
+       (error 'configuration-error
+              :message "Usage: /fast [on|off|status]."))))
+  nil)
 
 (-> application-set-reasoning-traces (application boolean) null)
 (defun application-set-reasoning-traces (application enabled-p)
@@ -2092,6 +2140,19 @@ are forwarded to TERMINAL-UI-SELECT."
        (format nil "Reasoning effort is now ~A."
                (configuration-reasoning-effort
                 (application-configuration application))))))
+  ':continue)
+
+(define-application-command application--builtin-fast-command
+    (:name "/fast"
+     :argument "[on|off|status]"
+     :description "show or change Codex Fast mode"
+     :tip "uses service_tier=fast at 2x plan usage for future Codex requests."
+     :busy-behavior :apply
+     :terminal-behavior :shared
+     :call-lambda-list (&optional mode)
+     :slash-argument-mode :first)
+    (application &optional mode)
+  (application-codex-fast-mode-command application mode)
   ':continue)
 
 (define-application-command application--builtin-trace-command

--- a/src/application/runtime.lisp
+++ b/src/application/runtime.lisp
@@ -1051,6 +1051,8 @@ newly acquired lease."
                    :model (configuration-model previous)
                    :reasoning-effort
                    (configuration-reasoning-effort previous)
+                    :codex-fast-mode-p
+                    (configuration-codex-fast-mode-p previous)
                    :immutable-p effective-immutable-p
                    :defer-provider-validation-p t))
                 (prepared-configuration

--- a/src/application/runtime.lisp
+++ b/src/application/runtime.lisp
@@ -2672,7 +2672,7 @@ remain finalized so later conversation replay cannot duplicate streamed rows."
 
 (-> application--status-details (application) terminal-styled-text)
 (defun application--status-details (application)
-  "Return cached-phase session, model, effort, and repository status spans."
+  "Return cached-phase session, model, effort, Fast mode, and repository status spans."
   (when (slot-boundp application 'configuration)
     (let* ((configuration (application-configuration application))
            (conversation
@@ -2698,6 +2698,9 @@ remain finalized so later conversation replay cannot duplicate streamed rows."
              (terminal-span ':status-dim " · ")
              (terminal-span ':status-effort
                             (configuration-reasoning-effort configuration)))
+       (when (configuration-codex-fast-mode-active-p configuration)
+         (list (terminal-span ':status-dim " · ")
+               (terminal-span ':status-accent "FAST")))
        (when branch
          (list (terminal-span ':status-dim " · git ")
                (terminal-span ':status-branch branch)))))))

--- a/src/configuration/preferences.lisp
+++ b/src/configuration/preferences.lisp
@@ -2,7 +2,7 @@
 
 ;;;; -- Global Preferences --
 
-(defparameter *preferences-version* 4
+(defparameter *preferences-version* 5
   "The readable global preferences file format version.")
 
 (defclass preference-state ()
@@ -18,6 +18,12 @@
     :reader preference-state-reasoning-effort
     :type (option non-empty-string)
     :documentation "The last interactively selected reasoning effort, if any.")
+   (codex-fast-mode-p
+    :initarg :codex-fast-mode-p
+    :initform nil
+    :reader preference-state-codex-fast-mode-p
+    :type boolean
+    :documentation "Whether Codex Fast mode is enabled for future requests.")
    (reasoning-traces-p
     :initarg :reasoning-traces-p
     :initform nil
@@ -74,7 +80,7 @@
                   (case version
                     (1
                      t)
-                    ((2 3 4)
+                    ((2 3 4 5)
                        (let ((model (getf properties :model))
                              (effort (getf properties :reasoning-effort))
                              (compact-present-p
@@ -89,6 +95,9 @@
                              (session-title-generation-present-p
                                (readable-state-property-present-p
                                 properties :session-title-generation-p))
+                             (codex-fast-mode-present-p
+                               (readable-state-property-present-p
+                                properties :codex-fast-mode-p))
                              (permission-mode
                                (getf properties :permission-mode))
                              (permission-mode-present-p
@@ -114,6 +123,9 @@
                               (typep
                                (getf properties :simple-technical-english-p)
                                'boolean))
+                          (or (not codex-fast-mode-present-p)
+                              (typep (getf properties :codex-fast-mode-p)
+                                     'boolean))
                           (or (not permission-mode-present-p)
                               (member permission-mode '(nil :ask :auto)
                                       :test #'eq))
@@ -123,7 +135,10 @@
                                'boolean))
                           (or (= version 2) compact-present-p)
                           (or (/= version 4)
-                              session-title-generation-present-p))))
+                              session-title-generation-present-p)
+                          (or (/= version 5)
+                              (and session-title-generation-present-p
+                                   codex-fast-mode-present-p)))))
                     (otherwise
                      nil)))))
     (error ()
@@ -136,6 +151,8 @@
       (make-instance 'preference-state
                      :model (getf properties :model)
                      :reasoning-effort (getf properties :reasoning-effort)
+                     :codex-fast-mode-p
+                     (getf properties :codex-fast-mode-p nil)
                      :reasoning-traces-p
                      (getf properties :reasoning-traces-p)
                      :compact-view-p (getf properties :compact-view-p t)
@@ -156,6 +173,8 @@
           :model (preference-state-model preferences)
           :reasoning-effort
           (preference-state-reasoning-effort preferences)
+          :codex-fast-mode-p
+          (preference-state-codex-fast-mode-p preferences)
           :reasoning-traces-p
           (preference-state-reasoning-traces-p preferences)
           :compact-view-p
@@ -226,6 +245,11 @@
   "Return the persisted reasoning-summary setting, defaulting safely to false."
   (preference-state-reasoning-traces-p (preferences-load configuration)))
 
+(-> preferences-codex-fast-mode-p (configuration) boolean)
+(defun preferences-codex-fast-mode-p (configuration)
+  "Return the persisted Codex Fast mode setting, defaulting safely to false."
+  (preference-state-codex-fast-mode-p (preferences-load configuration)))
+
 (-> preferences-compact-view-p (configuration) boolean)
 (defun preferences-compact-view-p (configuration)
   "Return the persisted compact tool-presentation setting, defaulting to true."
@@ -255,7 +279,7 @@
 
 (-> preferences-apply-model-selection (configuration) configuration)
 (defun preferences-apply-model-selection (configuration)
-  "Apply saved model and reasoning-effort choices when they remain valid.
+  "Apply saved model, effort, and Codex Fast mode choices when they remain valid.
 
 A saved model that no effective provider registration serves is dropped rather
 than applied, so removing a provider cannot leave the configuration naming a
@@ -263,6 +287,8 @@ model no provider can serve."
   (let* ((preferences (preferences-load configuration))
          (saved-model (preference-state-model preferences))
          (saved-effort (preference-state-reasoning-effort preferences))
+         (saved-codex-fast-mode-p
+           (preference-state-codex-fast-mode-p preferences))
          (selected configuration))
     (when (and saved-model
                (not (non-empty-string-p (uiop:getenv "AUTOLITH_MODEL")))
@@ -277,6 +303,11 @@ model no provider can serve."
                        :test #'string=))
       (setf selected
             (configuration-with-reasoning-effort selected saved-effort)))
+    (unless (non-empty-string-p (uiop:getenv "AUTOLITH_CODEX_FAST_MODE"))
+      (setf selected
+            (configuration-with-codex-fast-mode
+             selected
+             saved-codex-fast-mode-p)))
     selected))
 
 (-> preferences--write (configuration preference-state) null)
@@ -302,6 +333,7 @@ model no provider can serve."
      &key
      (:model (option non-empty-string))
      (:reasoning-effort (option non-empty-string))
+     (:codex-fast-mode-p boolean)
      (:reasoning-traces-p boolean)
      (:compact-view-p boolean)
      (:turn-timestamps-p boolean)
@@ -312,6 +344,8 @@ model no provider can serve."
 (defun preferences--copy
     (previous &key (model (preference-state-model previous))
                    (reasoning-effort (preference-state-reasoning-effort previous))
+                   (codex-fast-mode-p
+                    (preference-state-codex-fast-mode-p previous))
                    (reasoning-traces-p
                     (preference-state-reasoning-traces-p previous))
                    (compact-view-p (preference-state-compact-view-p previous))
@@ -326,6 +360,7 @@ model no provider can serve."
   (make-instance 'preference-state
                  :model model
                  :reasoning-effort reasoning-effort
+                 :codex-fast-mode-p codex-fast-mode-p
                  :reasoning-traces-p reasoning-traces-p
                  :compact-view-p compact-view-p
                  :turn-timestamps-p turn-timestamps-p
@@ -342,6 +377,15 @@ model no provider can serve."
     (preferences-load configuration)
     :model (configuration-model configuration)
     :reasoning-effort (configuration-reasoning-effort configuration)))
+  nil)
+
+(-> preferences-set-codex-fast-mode (configuration boolean) null)
+(defun preferences-set-codex-fast-mode (configuration enabled-p)
+  "Atomically persist Codex Fast mode without discarding other global choices."
+  (preferences--write
+   configuration
+   (preferences--copy (preferences-load configuration)
+                      :codex-fast-mode-p enabled-p))
   nil)
 
 (-> preferences-set-reasoning-traces (configuration boolean) null)

--- a/src/configuration/settings.lisp
+++ b/src/configuration/settings.lisp
@@ -231,6 +231,26 @@ configuration can be created before executable user initialization loads."
          (pathname value)
          fallback))))
 
+(-> environment-boolean (string boolean) boolean)
+(defun environment-boolean (variable fallback)
+  "Return boolean VARIABLE, or FALLBACK when it is unset."
+  (let ((value (uiop:getenv variable)))
+    (if (non-empty-string-p value)
+        (let ((normalized (string-downcase value)))
+          (cond
+            ((member normalized '("1" "true" "yes" "on") :test #'string=)
+             t)
+            ((member normalized '("0" "false" "no" "off") :test #'string=)
+             nil)
+            (t
+             (error 'configuration-error
+                    :message
+                    (format nil
+                            "~A must be on or off, not ~S."
+                            variable
+                            value)))))
+        fallback)))
+
 (-> configuration--default-config-root () pathname)
 (defun configuration--default-config-root ()
   "Return Autolith's default XDG configuration directory."
@@ -305,6 +325,12 @@ configuration can be created before executable user initialization loads."
     :reader configuration-reasoning-effort
     :type non-empty-string
     :documentation "The user-visible reasoning effort.")
+    (codex-fast-mode-p
+     :initarg :codex-fast-mode-p
+     :initform nil
+     :reader configuration-codex-fast-mode-p
+     :type boolean
+     :documentation "Whether Codex requests opt in to Fast mode.")
    (immutable-p
     :initarg :immutable-p
     :initform nil
@@ -433,41 +459,47 @@ AUTOLITH_MISTRAL_PROVIDER_ENDPOINT overrides the Mistral family endpoint."
                            (:working-directory (option pathname))
                            (:model (option string))
                            (:reasoning-effort (option string))
+                           (:codex-fast-mode-p boolean)
                            (:immutable-p boolean)
                            (:defer-provider-validation-p boolean))
     configuration)
 (defun configuration-create
-    (&key source-root working-directory model reasoning-effort immutable-p
-          defer-provider-validation-p)
+    (&key source-root working-directory model reasoning-effort
+      (codex-fast-mode-p nil codex-fast-mode-p-supplied-p)
+      immutable-p defer-provider-validation-p)
   "Create runtime configuration from explicit values and the environment.
 
 Provider-specific validation can be deferred until executable user
 initialization registers the selected model."
   (let* ((home (user-homedir-pathname))
-           (config-home (environment-directory
-                         "XDG_CONFIG_HOME"
-                         (merge-pathnames ".config/" home)))
-           (data-home (environment-directory
+         (config-home (environment-directory
+                       "XDG_CONFIG_HOME"
+                       (merge-pathnames ".config/" home)))
+         (data-home (environment-directory
                      "XDG_DATA_HOME"
                      (merge-pathnames ".local/share/" home)))
-           (state-home (environment-directory
-                        "XDG_STATE_HOME"
-                        (merge-pathnames ".local/state/" home)))
-           (cache-home (environment-directory
-                        "XDG_CACHE_HOME"
-                        (merge-pathnames ".cache/" home)))
-           (codex-home (environment-directory
-                        "CODEX_HOME"
-                        (merge-pathnames ".codex/" home)))
-           (environment-source-root (uiop:getenv "AUTOLITH_SOURCE_ROOT"))
-           (selected-model (or model (uiop:getenv "AUTOLITH_MODEL") *default-model*))
-           (selected-effort (or reasoning-effort
-                                (uiop:getenv "AUTOLITH_REASONING_EFFORT")
-                                *default-reasoning-effort*))
-           (selected-web-search (let ((mode (uiop:getenv "AUTOLITH_WEB_SEARCH")))
-                                  (if (non-empty-string-p mode)
-                                      (string-downcase mode)
-                                      "cached"))))
+         (state-home (environment-directory
+                      "XDG_STATE_HOME"
+                      (merge-pathnames ".local/state/" home)))
+         (cache-home (environment-directory
+                      "XDG_CACHE_HOME"
+                      (merge-pathnames ".cache/" home)))
+         (codex-home (environment-directory
+                      "CODEX_HOME"
+                      (merge-pathnames ".codex/" home)))
+         (environment-source-root (uiop:getenv "AUTOLITH_SOURCE_ROOT"))
+         (selected-model (or model (uiop:getenv "AUTOLITH_MODEL") *default-model*))
+         (selected-effort (or reasoning-effort
+                              (uiop:getenv "AUTOLITH_REASONING_EFFORT")
+                              *default-reasoning-effort*))
+         (selected-codex-fast-mode-p
+           (if codex-fast-mode-p-supplied-p
+               codex-fast-mode-p
+               (environment-boolean "AUTOLITH_CODEX_FAST_MODE" nil)))
+         (selected-web-search (let ((mode (uiop:getenv "AUTOLITH_WEB_SEARCH")))
+                                (if (non-empty-string-p mode)
+                                    (string-downcase mode)
+                                    "cached"))))
     (unless defer-provider-validation-p
       (unless (member selected-effort
                       (configuration--reasoning-efforts-for selected-model)
@@ -496,6 +528,7 @@ initialization registers the selected model."
                    (configuration--default-grok-bootstrap-path)
                    :model selected-model
                    :reasoning-effort selected-effort
+                   :codex-fast-mode-p selected-codex-fast-mode-p
                    :immutable-p immutable-p
                    :web-search-mode selected-web-search
                    :context-window (configuration--context-window-for
@@ -509,6 +542,7 @@ initialization registers the selected model."
     (configuration &key (:working-directory (option pathname))
                    (:model (option string))
                    (:reasoning-effort (option string))
+                   (:codex-fast-mode-p boolean)
                    (:immutable-p boolean)
                    (:web-search-mode (option string)))
     configuration)
@@ -516,6 +550,7 @@ initialization registers the selected model."
     (configuration
      &key working-directory model
        (reasoning-effort nil reasoning-effort-supplied-p)
+       (codex-fast-mode-p nil codex-fast-mode-p-supplied-p)
        (immutable-p nil immutable-p-supplied-p)
        (web-search-mode nil web-search-mode-supplied-p))
   "Copy CONFIGURATION, replacing only supplied workspace or model choices.
@@ -549,6 +584,10 @@ reasoning effort only when that effort is supported by the selected model."
                    (configuration-grok-bootstrap-auth-path configuration)
                    :model selected-model
                    :reasoning-effort selected-effort
+                   :codex-fast-mode-p
+                   (if codex-fast-mode-p-supplied-p
+                       codex-fast-mode-p
+                       (configuration-codex-fast-mode-p configuration))
                    :immutable-p (if immutable-p-supplied-p
                                     immutable-p
                                     (configuration-immutable-p configuration))
@@ -640,6 +679,11 @@ reasoning effort only when that effort is supported by the selected model."
                    reasoning-effort
                    (configuration-model configuration))))
   (configuration--clone configuration :reasoning-effort reasoning-effort))
+
+(-> configuration-with-codex-fast-mode (configuration boolean) configuration)
+(defun configuration-with-codex-fast-mode (configuration enabled-p)
+  "Copy CONFIGURATION with Codex Fast mode set to ENABLED-P."
+  (configuration--clone configuration :codex-fast-mode-p enabled-p))
 
 (-> configuration-with-model (configuration string) configuration)
 (defun configuration-with-model (configuration model)

--- a/src/configuration/settings.lisp
+++ b/src/configuration/settings.lisp
@@ -332,12 +332,12 @@ configuration can be created before executable user initialization loads."
     :reader configuration-reasoning-effort
     :type non-empty-string
     :documentation "The user-visible reasoning effort.")
-    (codex-fast-mode-p
-     :initarg :codex-fast-mode-p
-     :initform nil
-     :reader configuration-codex-fast-mode-p
-     :type boolean
-     :documentation "Whether Codex requests opt in to Fast mode.")
+   (codex-fast-mode-p
+    :initarg :codex-fast-mode-p
+    :initform nil
+    :reader configuration-codex-fast-mode-p
+    :type boolean
+    :documentation "Whether Codex requests opt in to Fast mode.")
    (immutable-p
     :initarg :immutable-p
     :initform nil

--- a/src/configuration/settings.lisp
+++ b/src/configuration/settings.lisp
@@ -175,6 +175,13 @@
     "accounts/fireworks/models/kimi-k3")
   "The model identifiers offered by the interactive model picker.")
 
+;; Fast capability metadata read from Codex reference commit
+;; 287587c32c9cbc1e78edbf2aaae6a6d84f5b0c56. Unknown and future models use
+;; the standard path until their catalog metadata is verified.
+(defparameter *codex-fast-mode-models*
+  '("gpt-5.6-sol" "gpt-5.6-luna" "gpt-5.6-terra")
+  "Codex model identifiers verified to support the Fast service tier.")
+
 ;; GPT window sizes read from the live Codex model catalog on 2026-07-19 and
 ;; confirmed in Codex reference commit 0fb559f0f6e231a88ac02ea002d3ecd248e2b515.
 ;; The Grok window comes from default_models.json in grok-build reference
@@ -361,6 +368,20 @@ configuration can be created before executable user initialization loads."
     :type non-empty-string
     :documentation "The streaming Responses endpoint."))
   (:documentation "Immutable paths and model choices for one Autolith process."))
+
+(-> configuration-codex-fast-mode-available-p (configuration) boolean)
+(defun configuration-codex-fast-mode-available-p (configuration)
+  "Return true when CONFIGURATION's current Codex model supports Fast mode."
+  (and (eq (model-family (configuration-model configuration)) ':codex)
+       (not (null (member (configuration-model configuration)
+                          *codex-fast-mode-models*
+                          :test #'string=)))))
+
+(-> configuration-codex-fast-mode-active-p (configuration) boolean)
+(defun configuration-codex-fast-mode-active-p (configuration)
+  "Return true when Fast mode is enabled and available for CONFIGURATION."
+  (and (configuration-codex-fast-mode-p configuration)
+       (configuration-codex-fast-mode-available-p configuration)))
 
 (-> configuration--provider-endpoint-for (string) string)
 (defun configuration--provider-endpoint-for (model)

--- a/src/core/package.lisp
+++ b/src/core/package.lisp
@@ -128,6 +128,7 @@
                 #:provider-progress-event
                 #:provider-request-object
                 #:provider-responses-hosted-tools
+                #:provider-responses-instructions-placement
                 #:provider-responses-reasoning-summary
                 #:provider-responses-request-fields
                 #:provider-responses-request-namespaces

--- a/src/inference/environment.lisp
+++ b/src/inference/environment.lisp
@@ -131,6 +131,16 @@ provider request on a closing remark."
     :documentation "The dedicated environment worker evaluating root forms."))
   (:documentation "Evaluate root model Lisp inside the run's environment."))
 
+(defmethod tool-execution-policy ((tool rlm-environment-tool))
+  "Serialize root environment forms because they share one mutable Lisp worker."
+  (declare (ignore tool))
+  ':exclusive)
+
+(defmethod tool-provider-round-trip-barrier-p ((tool rlm-environment-tool))
+  "Require the root model to observe one environment form before issuing another."
+  (declare (ignore tool))
+  t)
+
 (-> rlm-environment-tool-create (t) rlm-environment-tool)
 (defun rlm-environment-tool-create (worker)
   "Create the env.eval tool bound to one environment WORKER."

--- a/src/provider/builtins.lisp
+++ b/src/provider/builtins.lisp
@@ -119,7 +119,7 @@
  "chatgpt"
  :description "ChatGPT Codex subscription"
  :family ':codex
- :protocol ':responses-lite
+ :protocol ':responses
  :models '("gpt-5.6-sol"
            "gpt-5.6-luna"
            "gpt-5.6-terra")

--- a/src/provider/client.lisp
+++ b/src/provider/client.lisp
@@ -501,9 +501,9 @@ between roots while allowing a root and its task children to share a prefix."
   (declare (ignore provider))
   (conversation-prompt-cache-key conversation))
 
-;; Codex Fast mode uses service_tier="fast" only when the current model
-;; advertises Fast support. This follows Codex reference commit
-;; 287587c32c9cbc1e78edbf2aaae6a6d84f5b0c56.
+;; Codex Fast mode uses service_tier="priority", the canonical request value
+;; for Fast mode, only when the current model advertises support. This follows
+;; Codex reference commit 287587c32c9cbc1e78edbf2aaae6a6d84f5b0c56.
 (defmethod provider-request-object
     ((provider codex-subscription-provider)
      (conversation conversation)
@@ -511,7 +511,7 @@ between roots while allowing a root and its task children to share a prefix."
      &key goal-context compaction-p)
   "Build the complete stateless Sol Responses Lite request for CONVERSATION.
 
-Fast mode adds service_tier=fast; the standard path omits service_tier.
+Fast mode adds service_tier=priority; the standard path omits service_tier.
 GOAL-CONTEXT and resolved context contributions ride as transient developer
 messages that are never persisted in the durable conversation. Skill catalogs
 and explicitly selected bodies participate through that same context delivery.
@@ -586,7 +586,7 @@ delivery that the transport consumes only after a completed response."
                                                             conversation)
         "text" (json-object "verbosity" "low"))
         (when (configuration-codex-fast-mode-active-p configuration)
-          (list "service_tier" "fast"))
+          (list "service_tier" "priority"))
        (when (and *provider-maximum-output-tokens*
                   (provider-output-ceiling-p provider))
          (list "max_output_tokens" *provider-maximum-output-tokens*))))
@@ -639,7 +639,7 @@ checkpoint."
        "prompt_cache_key" (provider--codex-prompt-cache-key provider conversation)
        "text" (json-object "verbosity" "low"))
        (when (configuration-codex-fast-mode-active-p configuration)
-         (list "service_tier" "fast"))))))
+         (list "service_tier" "priority"))))))
 
 (-> provider-user-agent () string)
 (defun provider-user-agent ()

--- a/src/provider/client.lisp
+++ b/src/provider/client.lisp
@@ -387,11 +387,11 @@ so authentication can bootstrap credentials before model discovery."
    "POST REQUEST to PROVIDER's native compaction endpoint and return its body."))
 
 
-;;;; -- Responses Lite Encoding --
+;;;; -- Responses Encoding --
 
-(-> responses-lite-developer-message (string) json-object)
-(defun responses-lite-developer-message (instructions)
-  "Return the Responses Lite developer message containing INSTRUCTIONS."
+(-> responses-developer-message (string) json-object)
+(defun responses-developer-message (instructions)
+  "Return a standard Responses developer message containing INSTRUCTIONS."
   (json-object
    "type" "message"
    "role" "developer"
@@ -400,13 +400,101 @@ so authentication can bootstrap credentials before model discovery."
                "type" "input_text"
                "text" instructions))))
 
-(-> responses-lite-additional-tools (vector) json-object)
-(defun responses-lite-additional-tools (tool-namespaces)
-  "Return the Responses Lite developer item exposing TOOL-NAMESPACES."
+(defparameter *responses-standard-tool-name-maximum-length* 64
+  "Maximum standard Responses function name length accepted by Autolith.")
+
+(-> responses-standard-tool-name (string string) string)
+(defun responses-standard-tool-name (namespace name)
+  "Return a reversible grammar-safe name for NAMESPACE and NAME."
+  (let* ((payload
+           (concatenate 'string namespace (string (code-char 0)) name))
+         (encoded
+           (string-right-trim
+            "."
+            (usb8-array-to-base64-string
+             (sb-ext:string-to-octets payload :external-format ':utf-8)
+             :uri t)))
+         (wire-name (format nil "a~A" encoded)))
+    (when (> (length wire-name)
+             *responses-standard-tool-name-maximum-length*)
+      (error 'configuration-error
+             :message
+             (format nil
+                     "Tool name ~A.~A is too long for standard Responses."
+                     namespace name)))
+    wire-name))
+
+(-> responses-standard-tool-name->components
+    (string)
+    (values (option string) (option string)))
+(defun responses-standard-tool-name->components (wire-name)
+  "Decode a standard Responses function WIRE-NAME created by Autolith."
+  (if (and (plusp (length wire-name))
+           (char= (char wire-name 0) #\a))
+      (handler-case
+          (let* ((decoded
+                   (base64-string-to-string
+                    (padded-base64url (subseq wire-name 1))
+                    :uri t))
+                 (separator (position (code-char 0) decoded)))
+            (if (and separator
+                     (plusp separator)
+                     (< (1+ separator) (length decoded)))
+                (values (subseq decoded 0 separator)
+                        (subseq decoded (1+ separator)))
+                (values nil nil)))
+        (error ()
+          (values nil nil)))
+      (values nil nil)))
+
+(-> responses-standard-tool (string json-object) json-object)
+(defun responses-standard-tool (namespace tool)
+  "Encode one namespaced TOOL as a standard Responses function tool."
   (json-object
-   "type" "additional_tools"
-   "role" "developer"
-   "tools" tool-namespaces))
+   "type" "function"
+   "name" (responses-standard-tool-name namespace (json-get tool "name"))
+   "description" (json-get tool "description")
+   "strict" false
+   "parameters" (json-get tool "parameters")))
+
+(-> responses-standard-tools (vector) vector)
+(defun responses-standard-tools (tool-namespaces)
+  "Flatten TOOL-NAMESPACES for a standard Responses request."
+  (coerce
+   (loop for entry across tool-namespaces
+         if (and (json-object-p entry)
+                 (json-string= (json-get entry "type") "namespace")
+                 (vectorp (json-get entry "tools"))
+                 (non-empty-string-p (json-get entry "name")))
+           append (loop for tool across (json-get entry "tools")
+                        when (and (json-object-p tool)
+                                  (non-empty-string-p (json-get tool "name")))
+                          collect (responses-standard-tool
+                                   (json-get entry "name") tool))
+         else
+           collect entry)
+   'vector))
+
+(-> responses-standard-input-item (t) t)
+(defun responses-standard-input-item (item)
+  "Flatten a namespaced function-call ITEM for a standard Responses request."
+  (if (and (json-object-p item)
+           (function-call-item-p item)
+           (non-empty-string-p (json-get item "namespace"))
+           (non-empty-string-p (json-get item "name")))
+      (let ((copy (json-object-copy item)))
+        (setf (gethash "name" copy)
+              (responses-standard-tool-name
+               (json-get item "namespace")
+               (json-get item "name")))
+        (remhash "namespace" copy)
+        copy)
+      item))
+
+(-> responses-standard-instructions (list) string)
+(defun responses-standard-instructions (parts)
+  "Join non-empty instruction PARTS for a standard Responses request."
+  (format nil "~{~A~^~2%~}" (remove-if-not #'non-empty-string-p parts)))
 
 ;; Modeled on the Codex context checkpoint compaction instructions at
 ;; reference commit 6219b7c40f, restated for Autolith.
@@ -509,15 +597,10 @@ between roots while allowing a root and its task children to share a prefix."
      (conversation conversation)
      (tool-namespaces vector)
      &key goal-context compaction-p)
-  "Build the complete stateless Sol Responses Lite request for CONVERSATION.
+  "Build a standard Codex Responses request for CONVERSATION.
 
-Fast mode adds service_tier=priority; the standard path omits service_tier.
-GOAL-CONTEXT and resolved context contributions ride as transient developer
-messages that are never persisted in the durable conversation. Skill catalogs
-and explicitly selected bodies participate through that same context delivery.
-COMPACTION-P builds a tool-free summarization request whose trailing developer
-message asks for a context checkpoint handoff. The second value is the context
-delivery that the transport consumes only after a completed response."
+Fast mode adds service_tier=priority; the standard path omits service_tier. The
+second value is the context delivery consumed only after a completed response."
   (let* ((configuration (provider-configuration provider))
          (web-search-tool (and (not compaction-p)
                                (provider-web-search-tool configuration)))
@@ -531,19 +614,6 @@ delivery that the transport consumes only after a completed response."
                            (vector web-search-tool)))
              (t
               tool-namespaces)))
-         (reasoning
-           (json-object
-            "effort" (configuration-wire-effort configuration)
-            "context" "all_turns"))
-         (prefix (append
-                  (list (responses-lite-additional-tools effective-tools)
-                        (responses-lite-developer-message
-                         (let ((*system-prompt-hosted-web-search-p*
-                                 (not (null web-search-tool))))
-                           (system-prompt configuration))))
-                  (when (and goal-context
-                             (not compaction-p))
-                    (list (responses-lite-developer-message goal-context)))))
          (delivery
            (unless compaction-p
              (context-resolve-request
@@ -551,21 +621,28 @@ delivery that the transport consumes only after a completed response."
               conversation
               effective-tools
               :goal-context goal-context)))
-         (context-message
-           (and delivery
-                (context-delivery-rendered delivery)
-                (responses-lite-developer-message
-                 (context-delivery-rendered delivery))))
-         (input (coerce (append prefix
-                                (conversation-input-items-for-family
-                                 conversation
-                                 (provider-family provider)
-                                 :include-ephemeral-p (not compaction-p))
-                                (when context-message (list context-message))
-                                (when compaction-p
-                                  (list (responses-lite-developer-message
-                                        *compaction-instructions*))))
-                        'vector)))
+         (rendered-context
+           (and delivery (context-delivery-rendered delivery)))
+         (reasoning
+           (json-object
+            "effort" (configuration-wire-effort configuration)))
+         (instructions
+           (responses-standard-instructions
+            (list
+             (let ((*system-prompt-hosted-web-search-p*
+                     (not (null web-search-tool))))
+               (system-prompt configuration))
+             (and (not compaction-p) goal-context)
+             rendered-context
+             (and compaction-p *compaction-instructions*))))
+         (input
+           (map 'vector
+                #'responses-standard-input-item
+                (conversation-input-items-for-family
+                 conversation
+                 (provider-family provider)
+                 :include-ephemeral-p (not compaction-p))))
+         (tools (responses-standard-tools effective-tools)))
     (when (and (provider-reasoning-summaries-p provider)
                (not compaction-p))
       (setf (gethash "summary" reasoning) "auto"))
@@ -575,18 +652,22 @@ delivery that the transport consumes only after a completed response."
       (append
        (list
         "model" (configuration-model configuration)
+        "instructions" instructions
         "input" input
-        "tool_choice" "auto"
-        "parallel_tool_calls" false
+        "tools" tools)
+       (when (plusp (length tools))
+         (list "tool_choice" "auto"))
+       (list
+        "parallel_tool_calls" (if compaction-p false t)
         "reasoning" reasoning
         "store" false
         "stream" t
         "include" (json-array "reasoning.encrypted_content")
-        "prompt_cache_key" (provider--codex-prompt-cache-key provider
-                                                            conversation)
+        "prompt_cache_key" (provider--codex-prompt-cache-key
+                            provider conversation)
         "text" (json-object "verbosity" "low"))
-        (when (configuration-codex-fast-mode-active-p configuration)
-          (list "service_tier" "priority"))
+       (when (configuration-codex-fast-mode-active-p configuration)
+         (list "service_tier" "priority"))
        (when (and *provider-maximum-output-tokens*
                   (provider-output-ceiling-p provider))
          (list "max_output_tokens" *provider-maximum-output-tokens*))))
@@ -597,49 +678,35 @@ delivery that the transport consumes only after a completed response."
     json-object)
 (defun provider-native-compaction-request-object
     (provider conversation tool-namespaces)
-  "Build Codex's non-streaming Responses compaction request for CONVERSATION.
+  "Build a standard Responses compaction request for CONVERSATION.
 
-This mirrors the Responses Lite compaction payload at Codex reference commit
-ba42e6866cef4baed7ad92c73e6be8cd42e49d8b: durable family-compatible history
-receives the ordinary developer prefix without an extra compaction trigger.
-Request-local contributions and pending one-response items stay outside the
-checkpoint."
+Durable family-compatible history and top-level instructions participate in the
+native checkpoint. Request-local contributions and pending one-response items
+stay outside it."
+  (declare (ignore tool-namespaces))
   (let* ((configuration (provider-configuration provider))
-         (web-search-tool (provider-web-search-tool configuration))
-         (effective-tools
-           (if web-search-tool
-               (concatenate 'vector tool-namespaces (vector web-search-tool))
-               tool-namespaces))
-         (reasoning
-           (json-object
-            "effort" (configuration-wire-effort configuration)
-            "context" "all_turns"))
+         (instructions
+           (responses-standard-instructions
+            (list
+             (let ((*system-prompt-hosted-web-search-p* nil))
+               (system-prompt configuration)))))
          (input
-           (coerce
-            (append
-             (list (responses-lite-additional-tools effective-tools)
-                   (responses-lite-developer-message
-                    (let ((*system-prompt-hosted-web-search-p* nil))
-                      (system-prompt configuration))))
-             (conversation-input-items-for-family
-              conversation
-              (provider-family provider)
-              :include-ephemeral-p nil))
-            'vector)))
-    (when (provider-reasoning-summaries-p provider)
-      (setf (gethash "summary" reasoning) "auto"))
+           (map 'vector
+                #'responses-standard-input-item
+                (conversation-input-items-for-family
+                 conversation
+                 (provider-family provider)
+                 :include-ephemeral-p nil))))
     (apply
      #'json-object
      (append
       (list
        "model" (configuration-model configuration)
+       "instructions" instructions
        "input" input
-       "parallel_tool_calls" false
-       "reasoning" reasoning
-       "prompt_cache_key" (provider--codex-prompt-cache-key provider conversation)
-       "text" (json-object "verbosity" "low"))
-       (when (configuration-codex-fast-mode-active-p configuration)
-         (list "service_tier" "priority"))))))
+       "prompt_cache_key" (provider--codex-prompt-cache-key provider conversation))
+      (when (configuration-codex-fast-mode-active-p configuration)
+        (list "service_tier" "priority"))))))
 
 (-> provider-user-agent () string)
 (defun provider-user-agent ()
@@ -664,7 +731,6 @@ checkpoint."
     (cons "ChatGPT-Account-ID" (oauth-credentials-account-id credentials))
     (cons "Content-Type" "application/json")
     (cons "Accept" accept)
-    (cons "x-openai-internal-codex-responses-lite" "true")
     (cons "originator" "autolith")
     (cons "User-Agent" (provider-user-agent))
     (cons "session-id" (provider-session-id provider))
@@ -1819,7 +1885,7 @@ summary fallback."
     ((provider codex-subscription-provider)
      (conversation conversation)
      &key tool-namespaces event-callback)
-  "Compact CONVERSATION remotely, returning NIL only when the endpoint is absent."
+  "Compact CONVERSATION through the standard Responses compact endpoint."
   (declare (type vector tool-namespaces)
            (type function event-callback))
   (handler-case

--- a/src/provider/client.lisp
+++ b/src/provider/client.lisp
@@ -2,7 +2,7 @@
 
 ;;;; -- Provider Protocol --
 
-(defclass codex-subscription-provider (subscription-provider)
+(defclass codex-subscription-provider (responses-api-provider)
   ((reasoning-summaries-p
     :initarg :reasoning-summaries-p
     :initform nil
@@ -400,97 +400,6 @@ so authentication can bootstrap credentials before model discovery."
                "type" "input_text"
                "text" instructions))))
 
-(defparameter *responses-standard-tool-name-maximum-length* 64
-  "Maximum standard Responses function name length accepted by Autolith.")
-
-(-> responses-standard-tool-name (string string) string)
-(defun responses-standard-tool-name (namespace name)
-  "Return a reversible grammar-safe name for NAMESPACE and NAME."
-  (let* ((payload
-           (concatenate 'string namespace (string (code-char 0)) name))
-         (encoded
-           (string-right-trim
-            "."
-            (usb8-array-to-base64-string
-             (sb-ext:string-to-octets payload :external-format ':utf-8)
-             :uri t)))
-         (wire-name (format nil "a~A" encoded)))
-    (when (> (length wire-name)
-             *responses-standard-tool-name-maximum-length*)
-      (error 'configuration-error
-             :message
-             (format nil
-                     "Tool name ~A.~A is too long for standard Responses."
-                     namespace name)))
-    wire-name))
-
-(-> responses-standard-tool-name->components
-    (string)
-    (values (option string) (option string)))
-(defun responses-standard-tool-name->components (wire-name)
-  "Decode a standard Responses function WIRE-NAME created by Autolith."
-  (if (and (plusp (length wire-name))
-           (char= (char wire-name 0) #\a))
-      (handler-case
-          (let* ((decoded
-                   (base64-string-to-string
-                    (padded-base64url (subseq wire-name 1))
-                    :uri t))
-                 (separator (position (code-char 0) decoded)))
-            (if (and separator
-                     (plusp separator)
-                     (< (1+ separator) (length decoded)))
-                (values (subseq decoded 0 separator)
-                        (subseq decoded (1+ separator)))
-                (values nil nil)))
-        (error ()
-          (values nil nil)))
-      (values nil nil)))
-
-(-> responses-standard-tool (string json-object) json-object)
-(defun responses-standard-tool (namespace tool)
-  "Encode one namespaced TOOL as a standard Responses function tool."
-  (json-object
-   "type" "function"
-   "name" (responses-standard-tool-name namespace (json-get tool "name"))
-   "description" (json-get tool "description")
-   "strict" false
-   "parameters" (json-get tool "parameters")))
-
-(-> responses-standard-tools (vector) vector)
-(defun responses-standard-tools (tool-namespaces)
-  "Flatten TOOL-NAMESPACES for a standard Responses request."
-  (coerce
-   (loop for entry across tool-namespaces
-         if (and (json-object-p entry)
-                 (json-string= (json-get entry "type") "namespace")
-                 (vectorp (json-get entry "tools"))
-                 (non-empty-string-p (json-get entry "name")))
-           append (loop for tool across (json-get entry "tools")
-                        when (and (json-object-p tool)
-                                  (non-empty-string-p (json-get tool "name")))
-                          collect (responses-standard-tool
-                                   (json-get entry "name") tool))
-         else
-           collect entry)
-   'vector))
-
-(-> responses-standard-input-item (t) t)
-(defun responses-standard-input-item (item)
-  "Flatten a namespaced function-call ITEM for a standard Responses request."
-  (if (and (json-object-p item)
-           (function-call-item-p item)
-           (non-empty-string-p (json-get item "namespace"))
-           (non-empty-string-p (json-get item "name")))
-      (let ((copy (json-object-copy item)))
-        (setf (gethash "name" copy)
-              (responses-standard-tool-name
-               (json-get item "namespace")
-               (json-get item "name")))
-        (remhash "namespace" copy)
-        copy)
-      item))
-
 (-> responses-standard-instructions (list) string)
 (defun responses-standard-instructions (parts)
   "Join non-empty instruction PARTS for a standard Responses request."
@@ -592,86 +501,22 @@ between roots while allowing a root and its task children to share a prefix."
 ;; Codex Fast mode uses service_tier="priority", the canonical request value
 ;; for Fast mode, only when the current model advertises support. This follows
 ;; Codex reference commit 287587c32c9cbc1e78edbf2aaae6a6d84f5b0c56.
-(defmethod provider-request-object
-    ((provider codex-subscription-provider)
-     (conversation conversation)
-     (tool-namespaces vector)
-     &key goal-context compaction-p)
-  "Build a standard Codex Responses request for CONVERSATION.
 
-Fast mode adds service_tier=priority; the standard path omits service_tier. The
-second value is the context delivery consumed only after a completed response."
-  (let* ((configuration (provider-configuration provider))
-         (web-search-tool (and (not compaction-p)
-                               (provider-web-search-tool configuration)))
-         (effective-tools
-           (cond
-             (compaction-p
-              #())
-             (web-search-tool
-              (concatenate 'vector
-                           tool-namespaces
-                           (vector web-search-tool)))
-             (t
-              tool-namespaces)))
-         (delivery
-           (unless compaction-p
-             (context-resolve-request
-              configuration
-              conversation
-              effective-tools
-              :goal-context goal-context)))
-         (rendered-context
-           (and delivery (context-delivery-rendered delivery)))
-         (reasoning
-           (json-object
-            "effort" (configuration-wire-effort configuration)))
-         (instructions
-           (responses-standard-instructions
-            (list
-             (let ((*system-prompt-hosted-web-search-p*
-                     (not (null web-search-tool))))
-               (system-prompt configuration))
-             (and (not compaction-p) goal-context)
-             rendered-context
-             (and compaction-p *compaction-instructions*))))
-         (input
-           (map 'vector
-                #'responses-standard-input-item
-                (conversation-input-items-for-family
-                 conversation
-                 (provider-family provider)
-                 :include-ephemeral-p (not compaction-p))))
-         (tools (responses-standard-tools effective-tools)))
-    (when (and (provider-reasoning-summaries-p provider)
-               (not compaction-p))
-      (setf (gethash "summary" reasoning) "auto"))
-    (values
-     (apply
-      #'json-object
-      (append
-       (list
-        "model" (configuration-model configuration)
-        "instructions" instructions
-        "input" input
-        "tools" tools)
-       (when (plusp (length tools))
-         (list "tool_choice" "auto"))
-       (list
-        "parallel_tool_calls" (if compaction-p false t)
-        "reasoning" reasoning
-        "store" false
-        "stream" t
-        "include" (json-array "reasoning.encrypted_content")
-        "prompt_cache_key" (provider--codex-prompt-cache-key
-                            provider conversation)
-        "text" (json-object "verbosity" "low"))
-       (when (configuration-codex-fast-mode-active-p configuration)
-         (list "service_tier" "priority"))
-       (when (and *provider-maximum-output-tokens*
-                  (provider-output-ceiling-p provider))
-         (list "max_output_tokens" *provider-maximum-output-tokens*))))
-     delivery)))
+(-> provider--codex-responses-request-fields
+    (codex-subscription-provider conversation &key (:compaction-p boolean))
+    list)
+(defun provider--codex-responses-request-fields
+    (provider conversation &key compaction-p)
+  "Return Codex fields shared by the concrete and generic Responses views."
+  (let ((configuration (provider-configuration provider)))
+    (append
+     (list "parallel_tool_calls" (if compaction-p false t)
+           "include" (json-array "reasoning.encrypted_content")
+           "prompt_cache_key" (provider--codex-prompt-cache-key
+                               provider conversation)
+           "text" (json-object "verbosity" "low"))
+     (when (configuration-codex-fast-mode-active-p configuration)
+       (list "service_tier" "priority")))))
 
 (-> provider-native-compaction-request-object
     (codex-subscription-provider conversation vector)
@@ -690,13 +535,14 @@ stay outside it."
             (list
              (let ((*system-prompt-hosted-web-search-p* nil))
                (system-prompt configuration)))))
-         (input
-           (map 'vector
-                #'responses-standard-input-item
-                (conversation-input-items-for-family
-                 conversation
-                 (provider-family provider)
-                 :include-ephemeral-p nil))))
+          (input
+            (map 'vector
+                 (lambda (item)
+                   (provider-wire-input-item provider item))
+                 (conversation-input-items-for-family
+                  conversation
+                  (provider-family provider)
+                  :include-ephemeral-p nil))))
     (apply
      #'json-object
      (append

--- a/src/provider/client.lisp
+++ b/src/provider/client.lisp
@@ -501,10 +501,9 @@ between roots while allowing a root and its task children to share a prefix."
   (declare (ignore provider))
   (conversation-prompt-cache-key conversation))
 
-;; No service_tier field is ever sent. Omitting it selects the provider's
-;; standard processing path; sending "priority" selects the fast path that
-;; drains subscription rate limits much faster (Codex reference commit
-;; 5c19155c filters its explicit "default" sentinel out of requests too).
+;; Codex Fast mode uses service_tier="fast". Omitting the field selects the
+;; standard path. This mirrors Codex reference commit
+;; 3c1adbabcd0921f848f8c6122e6229689173d063.
 (defmethod provider-request-object
     ((provider codex-subscription-provider)
      (conversation conversation)
@@ -512,7 +511,7 @@ between roots while allowing a root and its task children to share a prefix."
      &key goal-context compaction-p)
   "Build the complete stateless Sol Responses Lite request for CONVERSATION.
 
-The request never carries a service_tier, keeping Autolith on the standard path.
+Fast mode adds service_tier=fast; the standard path omits service_tier.
 GOAL-CONTEXT and resolved context contributions ride as transient developer
 messages that are never persisted in the durable conversation. Skill catalogs
 and explicitly selected bodies participate through that same context delivery.
@@ -586,6 +585,8 @@ delivery that the transport consumes only after a completed response."
         "prompt_cache_key" (provider--codex-prompt-cache-key provider
                                                             conversation)
         "text" (json-object "verbosity" "low"))
+        (when (configuration-codex-fast-mode-p configuration)
+          (list "service_tier" "fast"))
        (when (and *provider-maximum-output-tokens*
                   (provider-output-ceiling-p provider))
          (list "max_output_tokens" *provider-maximum-output-tokens*))))
@@ -627,13 +628,18 @@ checkpoint."
             'vector)))
     (when (provider-reasoning-summaries-p provider)
       (setf (gethash "summary" reasoning) "auto"))
-    (json-object
-     "model" (configuration-model configuration)
-     "input" input
-     "parallel_tool_calls" false
-     "reasoning" reasoning
-     "prompt_cache_key" (provider--codex-prompt-cache-key provider conversation)
-     "text" (json-object "verbosity" "low"))))
+    (apply
+     #'json-object
+     (append
+      (list
+       "model" (configuration-model configuration)
+       "input" input
+       "parallel_tool_calls" false
+       "reasoning" reasoning
+       "prompt_cache_key" (provider--codex-prompt-cache-key provider conversation)
+       "text" (json-object "verbosity" "low"))
+       (when (configuration-codex-fast-mode-p configuration)
+         (list "service_tier" "fast"))))))
 
 (-> provider-user-agent () string)
 (defun provider-user-agent ()

--- a/src/provider/client.lisp
+++ b/src/provider/client.lisp
@@ -501,9 +501,9 @@ between roots while allowing a root and its task children to share a prefix."
   (declare (ignore provider))
   (conversation-prompt-cache-key conversation))
 
-;; Codex Fast mode uses service_tier="fast". Omitting the field selects the
-;; standard path. This mirrors Codex reference commit
-;; 3c1adbabcd0921f848f8c6122e6229689173d063.
+;; Codex Fast mode uses service_tier="fast" only when the current model
+;; advertises Fast support. This follows Codex reference commit
+;; 287587c32c9cbc1e78edbf2aaae6a6d84f5b0c56.
 (defmethod provider-request-object
     ((provider codex-subscription-provider)
      (conversation conversation)
@@ -585,7 +585,7 @@ delivery that the transport consumes only after a completed response."
         "prompt_cache_key" (provider--codex-prompt-cache-key provider
                                                             conversation)
         "text" (json-object "verbosity" "low"))
-        (when (configuration-codex-fast-mode-p configuration)
+        (when (configuration-codex-fast-mode-active-p configuration)
           (list "service_tier" "fast"))
        (when (and *provider-maximum-output-tokens*
                   (provider-output-ceiling-p provider))
@@ -638,7 +638,7 @@ checkpoint."
        "reasoning" reasoning
        "prompt_cache_key" (provider--codex-prompt-cache-key provider conversation)
        "text" (json-object "verbosity" "low"))
-       (when (configuration-codex-fast-mode-p configuration)
+       (when (configuration-codex-fast-mode-active-p configuration)
          (list "service_tier" "fast"))))))
 
 (-> provider-user-agent () string)

--- a/src/provider/fireworks/client.lisp
+++ b/src/provider/fireworks/client.lisp
@@ -88,9 +88,11 @@ request builder to omit the reasoning object entirely."
     (configuration-fireworks-wire-effort configuration)))
 
 (defmethod provider-responses-request-fields
-    ((provider fireworks-api-key-provider) (conversation conversation))
+    ((provider fireworks-api-key-provider)
+     (conversation conversation)
+     &key compaction-p)
   "Add CONVERSATION's stable Fireworks prompt cache key."
-  (declare (ignore provider))
+  (declare (ignore provider compaction-p))
   (list "prompt_cache_key" (conversation-prompt-cache-key conversation)))
 
 

--- a/src/provider/grok/client.lisp
+++ b/src/provider/grok/client.lisp
@@ -3,11 +3,10 @@
 ;;;; -- Grok Subscription Provider --
 
 ;;; The Grok subscription proxy speaks the standard streaming Responses API,
-;;; as read from grok-build reference commit 5163763e. Unlike the Codex
-;;; Responses Lite dialect, tools ride in the request's flat tools array and
-;;; function calls return one flat wire name, so this provider joins
-;;; Autolith's namespaced tool names with a dot on the way out and splits
-;;; them again on completed items. Conversations therefore persist in the
+;;; as read from grok-build reference commit 5163763e. Tools ride in the
+;;; request's flat tools array and function calls return one flat wire name, so
+;;; this provider joins Autolith's namespaced tool names with a dot on the way
+;;; out and splits them again on completed items. Conversations persist in the
 ;;; same namespaced shape regardless of the serving provider.
 ;;;
 ;;; Grok generation loops are stochastic, so the proxy offers a server-side
@@ -74,56 +73,6 @@
                  :registration (model-provider-registration provider)
                  :credential-manager (provider-credential-manager provider)
                  :session-id (provider-session-id provider)))
-
-
-;;;; -- Wire Tool Names --
-
-(-> grok-wire-tool-name (string string) string)
-(defun grok-wire-tool-name (namespace name)
-  "Return the flat Grok wire name of NAME inside NAMESPACE."
-  (format nil "~A.~A" namespace name))
-
-(-> grok-wire-tool (string json-object) json-object)
-(defun grok-wire-tool (namespace tool)
-  "Return namespaced TOOL as a standard Responses function tool."
-  (json-object
-   "type" "function"
-   "name" (grok-wire-tool-name namespace (json-get tool "name"))
-   "description" (json-get tool "description")
-   "strict" false
-   "parameters" (json-get tool "parameters")))
-
-(-> grok-wire-tools (vector) vector)
-(defun grok-wire-tools (tool-namespaces)
-  "Flatten namespaced TOOL-NAMESPACES into standard Responses function tools.
-
-Entries that are not tool namespaces pass through unchanged so hosted tools
-remain expressible."
-  (coerce
-   (loop for entry across tool-namespaces
-         if (and (json-object-p entry)
-                 (json-string= (json-get entry "type") "namespace")
-                 (vectorp (json-get entry "tools")))
-           append (loop for tool across (json-get entry "tools")
-                        when (json-object-p tool)
-                          collect (grok-wire-tool (json-get entry "name") tool))
-         else
-           collect entry)
-   'vector))
-
-(-> grok-wire-input-item (t) t)
-(defun grok-wire-input-item (item)
-  "Return ITEM with namespaced function calls flattened for the Grok wire."
-  (if (and (json-object-p item)
-           (function-call-item-p item)
-           (non-empty-string-p (json-get item "namespace")))
-      (let ((copy (json-object-copy item)))
-        (setf (gethash "name" copy)
-              (grok-wire-tool-name (json-get item "namespace")
-                                   (json-get item "name")))
-        (remhash "namespace" copy)
-        copy)
-      item))
 
 
 ;;;; -- Grok Protocol Specializations --

--- a/src/provider/grok/client.lisp
+++ b/src/provider/grok/client.lisp
@@ -166,12 +166,15 @@ proxy, so the local tool could only fail."
   "concise")
 
 (defmethod provider-responses-request-fields
-    ((provider grok-subscription-provider) (conversation conversation))
+    ((provider grok-subscription-provider)
+     (conversation conversation)
+     &key compaction-p)
   "Add Grok's encrypted reasoning, citation, and prompt-cache request fields.
 
 The no_inline_citations include suppresses inline citation markup during
 backend search, and the conversation identifier doubles as the prompt cache
 key, both matching Grok Build reference commit 5163763e."
+  (declare (ignore compaction-p))
   (let ((configuration (provider-configuration provider))
         (cache-key (conversation-prompt-cache-key conversation)))
     (append

--- a/src/provider/openai-compatible.lisp
+++ b/src/provider/openai-compatible.lisp
@@ -344,55 +344,25 @@ REGISTER-PROVIDER. MODELS-ENDPOINT discovers additional model identifiers."
 
 ;;;; -- Chat Completions Tool Encoding --
 
-(defparameter *openai-compatible-wire-tool-name-maximum-length* 64
+(defparameter *openai-compatible-wire-tool-name-maximum-length*
+    *provider-wire-function-name-maximum-length*
   "The maximum Chat Completions function name length accepted by Autolith.")
 
 (-> openai-compatible--wire-tool-name (string string) string)
 (defun openai-compatible--wire-tool-name (namespace name)
-  "Return a reversible grammar-safe name for NAMESPACE and NAME.
-
-The Chat Completions protocol does not accept dots in function names. A compact
-URL-safe Base64 payload keeps the namespace separator unambiguous while using only
-letters, digits, hyphens, and underscores on the wire."
-  (let* ((payload
-           (concatenate 'string namespace (string (code-char 0)) name))
-         (encoded
-           (string-right-trim
-            "."
-            (usb8-array-to-base64-string
-             (sb-ext:string-to-octets payload :external-format ':utf-8)
-             :uri t)))
-         (wire-name (format nil "a~A" encoded)))
-    (when (> (length wire-name) *openai-compatible-wire-tool-name-maximum-length*)
-      (error 'configuration-error
-             :message
-             (format nil
-                     "OpenAI-compatible tool name ~A.~A is too long for Chat Completions."
-                     namespace name)))
-    wire-name))
+  "Encode NAMESPACE and NAME with the shared grammar-safe provider codec."
+  (let ((*provider-wire-function-name-maximum-length*
+          *openai-compatible-wire-tool-name-maximum-length*))
+    (provider-wire-function-name--encode namespace name)))
 
 (-> openai-compatible--decode-wire-tool-name
     (string)
     (values (option string) (option string)))
 (defun openai-compatible--decode-wire-tool-name (wire-name)
   "Decode a namespaced Chat Completions function name, if it is ours."
-  (if (and (plusp (length wire-name))
-           (char= (char wire-name 0) #\a))
-      (handler-case
-          (let* ((decoded
-                   (base64-string-to-string
-                    (padded-base64url (subseq wire-name 1))
-                    :uri t))
-                 (separator (position (code-char 0) decoded)))
-            (if (and separator
-                     (plusp separator)
-                     (< (1+ separator) (length decoded)))
-                (values (subseq decoded 0 separator)
-                        (subseq decoded (1+ separator)))
-                (values nil nil)))
-        (error ()
-          (values nil nil)))
-      (values nil nil)))
+  (let ((*provider-wire-function-name-maximum-length*
+          *openai-compatible-wire-tool-name-maximum-length*))
+    (provider-wire-function-name--decode wire-name)))
 
 (-> openai-compatible--wire-function (string json-object) json-object)
 (defun openai-compatible--wire-function (name tool)

--- a/src/provider/wire-protocol.lisp
+++ b/src/provider/wire-protocol.lisp
@@ -1,11 +1,74 @@
 (in-package #:autolith)
 
-;;;; -- Provider Wire Protocols --
+;;;; -- Shared Function Names --
 
-(defmethod provider-wire-protocol ((provider codex-subscription-provider))
-  "Identify Codex as a standard Responses API provider."
+(defparameter *provider-wire-function-name-maximum-length* 64
+  "Maximum function name length accepted by the shared provider wire codec.")
+
+(-> provider-wire-function-name--valid-p (t) boolean)
+(defun provider-wire-function-name--valid-p (name)
+  "Return true when NAME obeys the standard provider function-name grammar."
+  (and (stringp name)
+       (plusp (length name))
+       (<= (length name) *provider-wire-function-name-maximum-length*)
+       (every (lambda (character)
+                (or (and (char<= #\a character) (char<= character #\z))
+                    (and (char<= #\A character) (char<= character #\Z))
+                    (and (char<= #\0 character) (char<= character #\9))
+                    (find character "_-")))
+              name)
+       t))
+
+(-> provider-wire-function-name--encode (string string) string)
+(defun provider-wire-function-name--encode (namespace name)
+  "Encode NAMESPACE and NAME as one reversible standard function name."
+  (let* ((payload
+           (concatenate 'string namespace (string (code-char 0)) name))
+         (encoded
+           (string-right-trim
+            "."
+            (usb8-array-to-base64-string
+             (sb-ext:string-to-octets payload :external-format ':utf-8)
+             :uri t)))
+         (wire-name (format nil "a~A" encoded)))
+    (unless (provider-wire-function-name--valid-p wire-name)
+      (error 'configuration-error
+             :message
+             (format nil
+                     "Tool name ~A.~A cannot fit the provider function-name grammar."
+                     namespace name)))
+    wire-name))
+
+(-> provider-wire-function-name--decode
+    (string)
+    (values (option string) (option string)))
+(defun provider-wire-function-name--decode (wire-name)
+  "Decode an Autolith provider function WIRE-NAME into namespace and name."
+  (if (and (provider-wire-function-name--valid-p wire-name)
+           (char= (char wire-name 0) #\a))
+      (handler-case
+          (let* ((decoded
+                   (base64-string-to-string
+                    (padded-base64url (subseq wire-name 1))
+                    :uri t))
+                 (separator (position (code-char 0) decoded)))
+            (if (and separator
+                     (plusp separator)
+                     (< (1+ separator) (length decoded)))
+                (values (subseq decoded 0 separator)
+                        (subseq decoded (1+ separator)))
+                (values nil nil)))
+        (error ()
+          (values nil nil)))
+      (values nil nil)))
+
+
+;;;; -- Responses Protocol --
+(defmethod provider-wire-tool-name
+    ((provider codex-subscription-provider) (namespace string) (name string))
+  "Encode one Codex tool name with the shared grammar-safe wire codec."
   (declare (ignore provider))
-  ':responses-api)
+  (provider-wire-function-name--encode namespace name))
 
 (defmethod provider-wire-tool
     ((provider responses-api-provider) (namespace string) (tool hash-table))
@@ -72,11 +135,46 @@
   (call-next-method)
   (when (function-call-item-p item)
     (multiple-value-bind (namespace name)
-        (responses-standard-tool-name->components (json-get item "name"))
+        (provider-wire-function-name--decode (json-get item "name"))
       (when (and namespace name)
         (setf (gethash "namespace" item) namespace
               (gethash "name" item) name))))
   item)
+
+(defmethod provider-responses-wire-effort
+    ((provider codex-subscription-provider) configuration)
+  "Return CONFIGURATION's Codex reasoning effort."
+  (declare (ignore provider))
+  (configuration-wire-effort configuration))
+
+(defmethod provider-responses-reasoning-summary
+    ((provider codex-subscription-provider) configuration)
+  "Request automatic Codex summaries when visible reasoning is enabled."
+  (declare (ignore configuration))
+  (when (provider-reasoning-summaries-p provider)
+    "auto"))
+
+(defmethod provider-responses-hosted-tools
+    ((provider codex-subscription-provider) configuration)
+  "Return Codex's enabled hosted tool declarations."
+  (declare (ignore provider))
+  (let ((web-search-tool (provider-web-search-tool configuration)))
+    (when web-search-tool
+      (list web-search-tool))))
+
+(defmethod provider-responses-instructions-placement
+    ((provider codex-subscription-provider))
+  "Place Codex instructions in the top-level Responses request field."
+  (declare (ignore provider))
+  ':top-level)
+
+(defmethod provider-responses-request-fields
+    ((provider codex-subscription-provider)
+     (conversation conversation)
+     &key compaction-p)
+  "Return the fields sent by one Codex Responses request."
+  (provider--codex-responses-request-fields
+   provider conversation :compaction-p compaction-p))
 
 (defmethod provider-request-object
     ((provider responses-api-provider)
@@ -85,9 +183,9 @@
      &key goal-context compaction-p)
   "Build a standard stateless Responses API request for CONVERSATION.
 
-Concrete providers specialize the reasoning effort, hosted tools, served
-namespaces, and extra request fields. The second value is the context
-delivery consumed only after a completed response."
+Concrete providers specialize instruction placement, reasoning effort, hosted
+tools, served namespaces, and extra request fields. The second value is the
+context delivery consumed only after a completed response."
   (let* ((configuration (provider-configuration provider))
          (hosted-tools
            (and (not compaction-p)
@@ -99,14 +197,6 @@ delivery consumed only after a completed response."
                             (provider-responses-request-namespaces
                              provider tool-namespaces)
                             (coerce hosted-tools 'vector))))
-         (prefix
-           (append
-            (list (responses-developer-message
-                   (let ((*system-prompt-hosted-web-search-p*
-                           (not (null hosted-tools))))
-                     (system-prompt configuration))))
-            (when (and goal-context (not compaction-p))
-              (list (responses-developer-message goal-context)))))
          (delivery
            (unless compaction-p
              (context-resolve-request
@@ -114,15 +204,45 @@ delivery consumed only after a completed response."
               conversation
               effective-namespaces
               :goal-context goal-context)))
-         (context-message
-           (and delivery
-                (context-delivery-rendered delivery)
-                (responses-developer-message
-                 (context-delivery-rendered delivery))))
+         (rendered-context
+           (and delivery (context-delivery-rendered delivery)))
+         (instruction-prefix
+           (list
+            (let ((*system-prompt-hosted-web-search-p*
+                    (not (null hosted-tools))))
+              (system-prompt configuration))
+            (and (not compaction-p) goal-context)))
+         (instruction-suffix
+           (list rendered-context
+                 (and compaction-p *compaction-instructions*)))
+         (instruction-placement
+           (provider-responses-instructions-placement provider))
+         (top-level-instructions
+           (case instruction-placement
+             (:input
+              nil)
+             (:top-level
+              (responses-standard-instructions
+               (append instruction-prefix instruction-suffix)))
+             (otherwise
+              (error 'configuration-error
+                     :message
+                     (format nil
+                             "Provider ~S returned unsupported Responses instruction placement ~S."
+                             (class-name (class-of provider))
+                             instruction-placement)))))
+         (input-prefix
+           (when (eq instruction-placement ':input)
+             (mapcar #'responses-developer-message
+                     (remove-if-not #'non-empty-string-p instruction-prefix))))
+         (input-suffix
+           (when (eq instruction-placement ':input)
+             (mapcar #'responses-developer-message
+                     (remove-if-not #'non-empty-string-p instruction-suffix))))
          (input
            (coerce
             (append
-             prefix
+             input-prefix
              (mapcar
               (lambda (item)
                 (provider-wire-input-item provider item))
@@ -130,18 +250,16 @@ delivery consumed only after a completed response."
                conversation
                (provider-family provider)
                :include-ephemeral-p (not compaction-p)))
-             (when context-message
-               (list context-message))
-             (when compaction-p
-               (list (responses-developer-message
-                      *compaction-instructions*))))
+             input-suffix)
             'vector))
          (tools (provider-wire-tools provider effective-namespaces)))
     (values
      (apply #'json-object
             (append
-             (list "model" (configuration-model configuration)
-                   "input" input
+             (list "model" (configuration-model configuration))
+             (when top-level-instructions
+               (list "instructions" top-level-instructions))
+             (list "input" input
                    "tools" tools)
              (when (plusp (length tools))
                (list "tool_choice" "auto"))
@@ -151,8 +269,9 @@ delivery consumed only after a completed response."
              (let ((effort
                      (provider-responses-wire-effort provider configuration))
                    (summary
-                     (provider-responses-reasoning-summary
-                      provider configuration)))
+                     (and (not compaction-p)
+                          (provider-responses-reasoning-summary
+                           provider configuration))))
                (when effort
                  (list "reasoning"
                        (apply #'json-object
@@ -165,5 +284,6 @@ delivery consumed only after a completed response."
                (list "max_output_tokens" *provider-maximum-output-tokens*))
              (list "store" false
                    "stream" t)
-             (provider-responses-request-fields provider conversation)))
+             (provider-responses-request-fields
+              provider conversation :compaction-p compaction-p)))
      delivery)))

--- a/src/provider/wire-protocol.lisp
+++ b/src/provider/wire-protocol.lisp
@@ -3,9 +3,9 @@
 ;;;; -- Provider Wire Protocols --
 
 (defmethod provider-wire-protocol ((provider codex-subscription-provider))
-  "Identify the Codex provider's Responses Lite dialect."
+  "Identify Codex as a standard Responses API provider."
   (declare (ignore provider))
-  ':responses-lite)
+  ':responses-api)
 
 (defmethod provider-wire-tool
     ((provider responses-api-provider) (namespace string) (tool hash-table))
@@ -66,6 +66,18 @@
               (gethash "name" item) (subseq name (1+ dot))))))
   item)
 
+(defmethod provider-normalize-output-item
+    ((provider codex-subscription-provider) (item hash-table))
+  "Restore standard Codex Responses calls to their local namespace shape."
+  (call-next-method)
+  (when (function-call-item-p item)
+    (multiple-value-bind (namespace name)
+        (responses-standard-tool-name->components (json-get item "name"))
+      (when (and namespace name)
+        (setf (gethash "namespace" item) namespace
+              (gethash "name" item) name))))
+  item)
+
 (defmethod provider-request-object
     ((provider responses-api-provider)
      (conversation conversation)
@@ -89,12 +101,12 @@ delivery consumed only after a completed response."
                             (coerce hosted-tools 'vector))))
          (prefix
            (append
-            (list (responses-lite-developer-message
+            (list (responses-developer-message
                    (let ((*system-prompt-hosted-web-search-p*
                            (not (null hosted-tools))))
                      (system-prompt configuration))))
             (when (and goal-context (not compaction-p))
-              (list (responses-lite-developer-message goal-context)))))
+              (list (responses-developer-message goal-context)))))
          (delivery
            (unless compaction-p
              (context-resolve-request
@@ -105,7 +117,7 @@ delivery consumed only after a completed response."
          (context-message
            (and delivery
                 (context-delivery-rendered delivery)
-                (responses-lite-developer-message
+                (responses-developer-message
                  (context-delivery-rendered delivery))))
          (input
            (coerce
@@ -121,7 +133,7 @@ delivery consumed only after a completed response."
              (when context-message
                (list context-message))
              (when compaction-p
-               (list (responses-lite-developer-message
+               (list (responses-developer-message
                       *compaction-instructions*))))
             'vector))
          (tools (provider-wire-tools provider effective-namespaces)))

--- a/src/task/state.lisp
+++ b/src/task/state.lisp
@@ -552,6 +552,11 @@ parent, and borrowed capabilities are released at terminal state."))
   (:documentation
    "Submit the required terminal result from a child agent."))
 
+(defmethod tool-execution-policy ((tool task-yield-tool))
+  "Execute the terminal child yield without concurrent sibling calls."
+  (declare (ignore tool))
+  ':exclusive)
+
 (defmethod tool-decode-arguments ((tool task-run-tool) source)
   "Decode task.run booleans without conflating JSON false and null."
   (declare (ignore tool))

--- a/src/tools/plan.lisp
+++ b/src/tools/plan.lisp
@@ -14,6 +14,11 @@
   ()
   (:documentation "A tool replacing the current workspace plan."))
 
+(defmethod tool-execution-policy ((tool plan-update-tool))
+  "Serialize plan replacement against the rest of one provider batch."
+  (declare (ignore tool))
+  ':exclusive)
+
 
 ;;;; -- Tool Executions --
 

--- a/src/tools/registry.lisp
+++ b/src/tools/registry.lisp
@@ -494,6 +494,36 @@
   "Allow ordinary tool calls to execute in provider wire order."
   nil)
 
+(-> tool-execution-policy (tool) (member :parallel :exclusive))
+(defgeneric tool-execution-policy (tool)
+  (:documentation
+   "Return whether TOOL may execute beside independent calls or needs exclusivity."))
+
+(defmethod tool-execution-policy ((tool tool))
+  "Run ordinary tools concurrently when the provider emits one call batch."
+  ':parallel)
+
+(defmethod tool-execution-policy ((tool resource-edit-tool))
+  "Serialize resource mutations so revision and persistence state remain ordered."
+  ':exclusive)
+
+(defmethod tool-execution-policy ((tool lisp-tool))
+  "Serialize Lisp worker operations until per-REPL execution keys are available."
+  ':exclusive)
+
+(defmethod tool-execution-policy ((tool mutable-self-tool))
+  "Serialize active-image mutations and lifecycle operations."
+  ':exclusive)
+
+(-> tool-concurrency-key (tool) t)
+(defgeneric tool-concurrency-key (tool)
+  (:documentation
+   "Return TOOL's shared runtime serialization key, or NIL when calls are independent."))
+
+(defmethod tool-concurrency-key ((tool tool))
+  "Serialize tools sharing one declared runtime identity."
+  (tool-runtime-identity tool))
+
 (-> tool-compact-result-visible-p (tool) boolean)
 (defgeneric tool-compact-result-visible-p (tool)
   (:documentation

--- a/src/tools/workspace.lisp
+++ b/src/tools/workspace.lisp
@@ -25,6 +25,11 @@
   "Permit authorized workspace commands inside child agents."
   t)
 
+(defmethod tool-execution-policy ((tool shell-run-tool))
+  "Serialize shell commands because they may mutate shared workspace state."
+  (declare (ignore tool))
+  ':exclusive)
+
 
 ;;;; -- Workspace Defaults --
 

--- a/tests/agent-tests.lisp
+++ b/tests/agent-tests.lisp
@@ -145,6 +145,128 @@
    (format nil "echo: ~A"
            (tool-argument arguments "value" :required t))))
 
+(defclass agent-test-concurrency-state ()
+  ((lock
+    :initform (make-lock "Autolith agent test tool state")
+    :reader agent-test-concurrency-state-lock
+    :documentation "The lock protecting mutable execution state.")
+   (condition-variable
+    :initform (make-condition-variable)
+    :reader agent-test-concurrency-state-condition-variable
+    :documentation "The condition used to align concurrent tool starts.")
+   (active-count
+    :initform 0
+    :accessor agent-test-concurrency-state-active-count
+    :type (integer 0)
+    :documentation "The number of currently executing test tools.")
+   (maximum-active-count
+    :initform 0
+    :accessor agent-test-concurrency-state-maximum-active-count
+    :type (integer 0)
+    :documentation "The largest observed concurrent execution count.")
+   (overlap-observed-p
+    :initform nil
+    :accessor agent-test-concurrency-state-overlap-observed-p
+    :type boolean
+    :documentation "Whether two tool bodies executed at the same time.")
+   (events
+    :initform nil
+    :accessor agent-test-concurrency-state-events
+    :type list
+    :documentation "Execution start and finish events in reverse time order."))
+  (:documentation "Shared state for deterministic concurrent tool tests."))
+
+(defclass agent-test-concurrent-tool (tool)
+  ((state
+    :initarg :state
+    :reader agent-test-concurrent-tool-state
+    :type agent-test-concurrency-state
+    :documentation "The shared execution state recorded by this tool.")
+   (execution-policy
+    :initarg :execution-policy
+    :initform ':parallel
+    :reader agent-test-concurrent-tool-execution-policy
+    :type (member :parallel :exclusive)
+    :documentation "Whether this test tool requires exclusive execution.")
+   (concurrency-key
+    :initarg :concurrency-key
+    :initform nil
+    :reader agent-test-concurrent-tool-concurrency-key
+    :type t
+    :documentation "The optional runtime key shared with conflicting tools."))
+  (:documentation "A deterministic tool that records and aligns execution."))
+
+(defmethod tool-execution-policy ((tool agent-test-concurrent-tool))
+  "Return TOOL's configured execution policy."
+  (agent-test-concurrent-tool-execution-policy tool))
+
+(defmethod tool-concurrency-key ((tool agent-test-concurrent-tool))
+  "Return TOOL's configured shared-runtime key."
+  (agent-test-concurrent-tool-concurrency-key tool))
+
+(defmethod tool-execute ((tool agent-test-concurrent-tool)
+                         (context tool-context)
+                         (arguments hash-table))
+  "Record one test execution, optionally aligning it with a sibling call."
+  (let* ((state
+           (agent-test-concurrent-tool-state tool))
+         (label
+           (tool-argument arguments "label" :required t))
+         (delay
+           (or (tool-argument arguments "delay") 0.0d0))
+         (await-peer-p
+           (eq (tool-argument arguments "await_peer") t))
+         (fail-p
+           (eq (tool-argument arguments "fail") t))
+         (fatal
+           (tool-argument arguments "fatal")))
+    (with-lock-held ((agent-test-concurrency-state-lock state))
+      (incf (agent-test-concurrency-state-active-count state))
+      (setf (agent-test-concurrency-state-maximum-active-count state)
+            (max (agent-test-concurrency-state-maximum-active-count state)
+                 (agent-test-concurrency-state-active-count state)))
+      (push (list ':start label)
+            (agent-test-concurrency-state-events state))
+      (when (> (agent-test-concurrency-state-active-count state) 1)
+        (setf (agent-test-concurrency-state-overlap-observed-p state) t)
+        (condition-notify
+         (agent-test-concurrency-state-condition-variable state)))
+      (when (and await-peer-p
+                 (= (agent-test-concurrency-state-active-count state) 1))
+        (condition-wait
+         (agent-test-concurrency-state-condition-variable state)
+         (agent-test-concurrency-state-lock state)
+         :timeout 0.5)))
+    (unwind-protect
+         (progn
+           (agent-observer-status
+            (tool-context-observer context)
+            ':agent-test-tool-callback
+            (list :label label))
+           (sleep delay)
+           (when fail-p
+             (error "requested test failure"))
+           (cond
+             ((equal fatal "rollback")
+              (error 'rollback-requested
+                     :message "requested rollback test"
+                     :generation-id "test-generation"))
+             ((equal fatal "corruption")
+              (error
+               'active-image-corruption
+               :message "requested corruption test"
+               :original-condition
+               (make-condition 'simple-error
+                               :format-control "original failure")
+               :restoration-condition
+               (make-condition 'simple-error
+                               :format-control "restoration failure"))))
+           (tool-success (format nil "completed: ~A" label)))
+      (with-lock-held ((agent-test-concurrency-state-lock state))
+        (push (list ':finish label)
+              (agent-test-concurrency-state-events state))
+        (decf (agent-test-concurrency-state-active-count state))))))
+
 (-> agent-test-registry () tool-registry)
 (defun agent-test-registry ()
   "Return a registry containing the deterministic echo tool."
@@ -225,6 +347,49 @@
                  :usage (json-object "input_tokens" 1 "output_tokens" 1)
                  :turn-state turn-state
                  :turn-completion turn-completion))
+
+(-> agent-test-concurrency-tool
+    (agent-test-concurrency-state string
+     &key (:execution-policy (member :parallel :exclusive))
+          (:concurrency-key t))
+    agent-test-concurrent-tool)
+(defun agent-test-concurrency-tool
+    (state name &key (execution-policy ':parallel) concurrency-key)
+  "Create one concurrency test tool named NAME sharing STATE."
+  (make-instance
+   'agent-test-concurrent-tool
+   :namespace "concurrency"
+   :name name
+   :description "Record deterministic concurrent execution."
+   :parameters
+   (tool-object-schema
+    (json-object
+     "label" (tool-string-property "The execution label.")
+     "delay" (json-object "type" "number")
+     "await_peer" (tool-boolean-property "Wait for one concurrent peer.")
+     "fail" (tool-boolean-property "Signal a test failure.")
+     "fatal" (tool-string-property
+              "The optional fatal condition kind to signal."))
+    '("label"))
+   :state state
+   :execution-policy execution-policy
+   :concurrency-key concurrency-key))
+
+(-> agent-test-concurrency-registry (list) tool-registry)
+(defun agent-test-concurrency-registry (tools)
+  "Return a registry containing concurrency test TOOLS."
+  (let ((registry (make-instance 'tool-registry)))
+    (dolist (tool tools)
+      (tool-registry-register registry tool))
+    registry))
+
+(-> agent-test-tool-outputs (conversation) list)
+(defun agent-test-tool-outputs (conversation)
+  "Return provider-visible tool outputs from CONVERSATION in durable order."
+  (loop for item in (conversation-input-items conversation)
+        when (string= (or (json-get item "type") "")
+                      "function_call_output")
+          collect (json-get item "output")))
 
 (-> test-agent-tool-loop () null)
 (defun test-agent-tool-loop ()
@@ -1663,6 +1828,337 @@
       (uiop:delete-directory-tree root :validate t :if-does-not-exist ':ignore)))
   nil)
 
+(-> test-agent-parallel-tool-wave () null)
+(defun test-agent-parallel-tool-wave ()
+  "Test independent calls overlap while callbacks and persistence stay ordered."
+  (let* ((configuration (test-configuration))
+         (root (test-configuration-root configuration))
+         (conversation
+           (conversation-create configuration :identifier "agent-parallel-wave"))
+         (state (make-instance 'agent-test-concurrency-state))
+         (tool (agent-test-concurrency-tool state "run"))
+         (registry (agent-test-concurrency-registry (list tool)))
+         (provider
+           (make-instance
+            'scripted-provider
+            :results
+            (list
+             (agent-test-result
+              "parallel-calls"
+              (list
+               (agent-test-call
+                :call-id "parallel-a"
+                :namespace "concurrency"
+                :name "run"
+                :arguments
+                "{\"label\":\"a\",\"delay\":0.05,\"await_peer\":true}")
+               (agent-test-call
+                :call-id "parallel-b"
+                :namespace "concurrency"
+                :name "run"
+                :arguments
+                "{\"label\":\"b\",\"await_peer\":true}")))
+             (agent-test-result
+              "parallel-done"
+              (list (agent-test-message "done"))))))
+         (callback-lock (make-lock "Autolith observer callback test"))
+         (callback-active-count 0)
+         (callback-maximum-active-count 0)
+         (observer
+           (callback-agent-observer-create
+            :status-callback
+            (lambda (status details)
+              (declare (ignore details))
+              (when (eq status ':agent-test-tool-callback)
+                (with-lock-held (callback-lock)
+                  (incf callback-active-count)
+                  (setf callback-maximum-active-count
+                        (max callback-maximum-active-count
+                             callback-active-count)))
+                (sleep 0.02)
+                (with-lock-held (callback-lock)
+                  (decf callback-active-count)))))))
+    (unwind-protect
+         (let ((agent
+                 (agent-create
+                  :configuration configuration
+                  :provider provider
+                  :conversation conversation
+                  :tool-registry registry
+                  :worker ':unused)))
+           (agent-run-user-turn agent "run both" :observer observer)
+           (test-assert
+            (agent-test-concurrency-state-overlap-observed-p state)
+            "independent tool bodies overlap")
+           (test-assert
+            (= (agent-test-concurrency-state-maximum-active-count state) 2)
+            "one provider batch uses two concurrent tool workers")
+           (test-assert
+            (= callback-maximum-active-count 1)
+            "observer callbacks remain serialized across tool workers")
+           (test-assert
+            (equal (agent-test-tool-outputs conversation)
+                   '("completed: a" "completed: b"))
+            "tool outputs persist in provider wire order")
+           (let ((events
+                   (reverse (agent-test-concurrency-state-events state))))
+             (test-assert
+              (and (every (lambda (event)
+                            (eq (first event) ':start))
+                          (subseq events 0 2))
+                   (equal (subseq events 2)
+                          '((:finish "b") (:finish "a"))))
+              "both bodies start before reverse completion finishes")))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist ':ignore)))
+  nil)
+
+(-> test-agent-tool-concurrency-key () null)
+(defun test-agent-tool-concurrency-key ()
+  "Test calls sharing one runtime identity execute in separate waves."
+  (let* ((configuration (test-configuration))
+         (root (test-configuration-root configuration))
+         (conversation
+           (conversation-create configuration :identifier "agent-runtime-key"))
+         (state (make-instance 'agent-test-concurrency-state))
+         (runtime (list ':shared-runtime))
+         (tool (agent-test-concurrency-tool
+                state "keyed" :concurrency-key runtime))
+         (provider
+           (make-instance
+            'scripted-provider
+            :results
+            (list
+             (agent-test-result
+              "keyed-calls"
+              (list
+               (agent-test-call
+                :call-id "keyed-a"
+                :namespace "concurrency"
+                :name "keyed"
+                :arguments "{\"label\":\"a\",\"delay\":0.03}")
+               (agent-test-call
+                :call-id "keyed-b"
+                :namespace "concurrency"
+                :name "keyed"
+                :arguments "{\"label\":\"b\",\"delay\":0.03}")))
+             (agent-test-result
+              "keyed-done"
+              (list (agent-test-message "done")))))))
+    (unwind-protect
+         (let ((agent
+                 (agent-create
+                  :configuration configuration
+                  :provider provider
+                  :conversation conversation
+                  :tool-registry
+                  (agent-test-concurrency-registry (list tool))
+                  :worker ':unused)))
+           (agent-run-user-turn agent "run keyed calls")
+           (test-assert
+            (= (agent-test-concurrency-state-maximum-active-count state) 1)
+            "calls sharing one runtime key do not overlap")
+           (test-assert
+            (equal (reverse (agent-test-concurrency-state-events state))
+                   '((:start "a") (:finish "a")
+                     (:start "b") (:finish "b")))
+            "shared-runtime calls preserve provider order"))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist ':ignore)))
+  nil)
+
+(-> test-agent-exclusive-tool-waves () null)
+(defun test-agent-exclusive-tool-waves ()
+  "Test an exclusive call divides parallel calls into ordered waves."
+  (test-assert
+   (eq (tool-execution-policy
+        (make-instance 'shell-run-tool
+                       :namespace "shell"
+                       :name "run"
+                       :description "Run one command."
+                       :parameters (json-object)))
+       ':exclusive)
+   "shell commands opt into exclusive ordered waves")
+  (let* ((configuration (test-configuration))
+         (root (test-configuration-root configuration))
+         (conversation
+           (conversation-create configuration :identifier "agent-exclusive-wave"))
+         (state (make-instance 'agent-test-concurrency-state))
+         (before (agent-test-concurrency-tool state "before"))
+         (exclusive
+           (agent-test-concurrency-tool
+            state "exclusive" :execution-policy ':exclusive))
+         (after (agent-test-concurrency-tool state "after"))
+         (provider
+           (make-instance
+            'scripted-provider
+            :results
+            (list
+             (agent-test-result
+              "exclusive-calls"
+              (list
+               (agent-test-call
+                :call-id "before"
+                :namespace "concurrency"
+                :name "before"
+                :arguments "{\"label\":\"before\",\"delay\":0.02}")
+               (agent-test-call
+                :call-id "exclusive"
+                :namespace "concurrency"
+                :name "exclusive"
+                :arguments "{\"label\":\"exclusive\",\"delay\":0.02}")
+               (agent-test-call
+                :call-id "after"
+                :namespace "concurrency"
+                :name "after"
+                :arguments "{\"label\":\"after\",\"delay\":0.02}")))
+             (agent-test-result
+              "exclusive-done"
+              (list (agent-test-message "done")))))))
+    (unwind-protect
+         (let ((agent
+                 (agent-create
+                  :configuration configuration
+                  :provider provider
+                  :conversation conversation
+                  :tool-registry
+                  (agent-test-concurrency-registry
+                   (list before exclusive after))
+                  :worker ':unused)))
+           (agent-run-user-turn agent "run exclusive call")
+           (test-assert
+            (= (agent-test-concurrency-state-maximum-active-count state) 1)
+            "exclusive execution prevents overlap across adjacent waves")
+           (test-assert
+            (equal (reverse (agent-test-concurrency-state-events state))
+                   '((:start "before") (:finish "before")
+                     (:start "exclusive") (:finish "exclusive")
+                     (:start "after") (:finish "after")))
+            "the exclusive call divides calls into ordered waves"))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist ':ignore)))
+  nil)
+
+(-> test-agent-parallel-tool-failure () null)
+(defun test-agent-parallel-tool-failure ()
+  "Test one failed parallel call does not discard its sibling result."
+  (let* ((configuration (test-configuration))
+         (root (test-configuration-root configuration))
+         (conversation
+           (conversation-create configuration :identifier "agent-parallel-failure"))
+         (state (make-instance 'agent-test-concurrency-state))
+         (tool (agent-test-concurrency-tool state "fail"))
+         (provider
+           (make-instance
+            'scripted-provider
+            :results
+            (list
+             (agent-test-result
+              "failure-calls"
+              (list
+               (agent-test-call
+                :call-id "failed"
+                :namespace "concurrency"
+                :name "fail"
+                :arguments
+                "{\"label\":\"failed\",\"await_peer\":true,\"fail\":true}")
+               (agent-test-call
+                :call-id "sibling"
+                :namespace "concurrency"
+                :name "fail"
+                :arguments
+                "{\"label\":\"sibling\",\"await_peer\":true}")))
+             (agent-test-result
+              "failure-done"
+              (list (agent-test-message "done")))))))
+    (unwind-protect
+         (let ((agent
+                 (agent-create
+                  :configuration configuration
+                  :provider provider
+                  :conversation conversation
+                  :tool-registry
+                  (agent-test-concurrency-registry (list tool))
+                  :worker ':unused)))
+           (agent-run-user-turn agent "run failing calls")
+           (let ((outputs (agent-test-tool-outputs conversation)))
+             (test-assert
+              (= (length outputs) 2)
+              "both parallel calls persist outputs after one fails")
+             (test-assert
+              (search "requested test failure" (first outputs))
+              "the failed call persists its failure output")
+             (test-assert
+              (string= (second outputs) "completed: sibling")
+              "the successful sibling result remains available")))
+      (uiop:delete-directory-tree root :validate t :if-does-not-exist ':ignore)))
+  nil)
+
+(-> test-agent-parallel-fatal-propagation () null)
+(defun test-agent-parallel-fatal-propagation ()
+  "Test fatal tool conditions propagate after concurrent siblings complete."
+  (dolist (case '(("rollback" rollback-requested)
+                  ("corruption" active-image-corruption)))
+    (destructuring-bind (fatal expected-type) case
+      (let* ((configuration (test-configuration))
+             (root (test-configuration-root configuration))
+             (conversation
+               (conversation-create
+                configuration
+                :identifier (format nil "agent-fatal-~A" fatal)))
+             (state (make-instance 'agent-test-concurrency-state))
+             (tool (agent-test-concurrency-tool state "fatal"))
+             (provider
+               (make-instance
+                'scripted-provider
+                :results
+                (list
+                 (agent-test-result
+                  "fatal-calls"
+                  (list
+                   (agent-test-call
+                    :call-id "fatal"
+                    :namespace "concurrency"
+                    :name "fatal"
+                    :arguments
+                    (format nil
+                            "{\"label\":\"fatal\",\"await_peer\":true,\"fatal\":\"~A\"}"
+                            fatal))
+                   (agent-test-call
+                    :call-id "sibling"
+                    :namespace "concurrency"
+                    :name "fatal"
+                    :arguments
+                    "{\"label\":\"sibling\",\"await_peer\":true}")))))))
+        (unwind-protect
+             (let* ((agent
+                      (agent-create
+                       :configuration configuration
+                       :provider provider
+                       :conversation conversation
+                       :tool-registry
+                       (agent-test-concurrency-registry (list tool))
+                       :worker ':unused))
+                    (condition
+                      (handler-case
+                          (progn
+                            (agent-run-user-turn agent "run fatal calls")
+                            nil)
+                        (rollback-requested (failure)
+                          failure)
+                        (active-image-corruption (failure)
+                          failure))))
+               (test-assert
+                (typep condition expected-type)
+                "the original fatal tool condition reaches the agent caller")
+               (test-assert
+                (agent-test-concurrency-state-overlap-observed-p state)
+                "the fatal call executes concurrently with its sibling")
+               (test-assert
+                (equal (agent-test-tool-outputs conversation)
+                       '("completed: sibling"))
+                "the sibling result persists before fatal propagation"))
+          (uiop:delete-directory-tree
+           root :validate t :if-does-not-exist ':ignore)))))
+  nil)
+
 (-> run-agent-tests () boolean)
 (defun run-agent-tests ()
   "Run focused agent-loop tests and return true on success."
@@ -1685,4 +2181,10 @@
   (test-agent-skill-provider-barrier)
   (test-agent-compaction)
   (test-agent-native-compaction)
+  (test-agent-parallel-tool-wave)
+  (test-agent-tool-concurrency-key)
+  (test-agent-exclusive-tool-waves)
+  (test-agent-parallel-tool-failure)
+  (test-agent-parallel-fatal-propagation)
   t)
+      

--- a/tests/agent-tests.lisp
+++ b/tests/agent-tests.lisp
@@ -2187,4 +2187,3 @@
   (test-agent-parallel-tool-failure)
   (test-agent-parallel-fatal-propagation)
   t)
-      

--- a/tests/application-command-tests.lisp
+++ b/tests/application-command-tests.lisp
@@ -424,6 +424,8 @@
          ("/model gpt-5.6-sol" :apply)
          ("/effort" :hold)
          ("/effort high" :apply)
+          ("/fast" :execute)
+          ("/fast on" :apply)
          ("/trace" :execute)
          ("/trace on" :apply)
          ("/timestamps" :execute)
@@ -494,6 +496,7 @@
          ("/auth" (&optional (provider-name nil provider-name-supplied-p)) :remainder)
          ("/model" (&optional (model nil model-supplied-p)) :first)
          ("/trace" (mode) :first)
+         ("/fast" (&optional mode) :first)
          ("/permissions" (&optional (choice nil choice-supplied-p)) :first)
          ("/later" (input) :remainder)
          ("/goal" (&optional (remainder "")) :remainder)
@@ -572,6 +575,106 @@
     (test-assert
      (application-project-adaptation-offer-p application)
      "nonmodal resume calls do not consume the interactive startup offer"))
+  nil)
+
+(-> test-application-codex-fast-mode-command () null)
+(defun test-application-codex-fast-mode-command ()
+  "Test /fast status, persistence, runtime installation, and validation."
+  (let* ((configuration
+           (configuration-with-codex-fast-mode (test-configuration) nil))
+         (root (test-configuration-root configuration))
+         (application (make-instance 'application
+                                     :configuration configuration))
+         (presented nil)
+         (persisted nil)
+         (installed nil)
+         (published-count 0))
+    (unwind-protect
+         (test-call-with-function-replacements
+          (list
+           (list
+            'application-present
+            (lambda (candidate entry)
+              (declare (ignore candidate))
+              (push entry presented)
+              t))
+           (list
+            'preferences-set-codex-fast-mode
+            (lambda (candidate enabled-p)
+              (push (list enabled-p
+                          (configuration-codex-fast-mode-p candidate))
+                    persisted)
+              nil))
+           (list
+            'application--install-configuration
+            (lambda (candidate replacement &key conversation)
+              (declare (ignore conversation))
+              (setf (application-configuration candidate) replacement)
+              (push (configuration-codex-fast-mode-p replacement) installed)
+              nil))
+           (list
+            'application-publish-recovery-session
+            (lambda (candidate)
+              (declare (ignore candidate))
+              (incf published-count)
+              nil)))
+          (lambda ()
+            (test-assert
+             (eq (application--builtin-fast-command application) ':continue)
+             "/fast status completes through the canonical command")
+            (test-assert
+             (search "Codex Fast mode is off." (first presented))
+             "/fast reports the disabled state")
+            (test-assert
+             (eq (application--builtin-fast-command application "status")
+                 ':continue)
+             "/fast status accepts its explicit spelling")
+            (test-assert
+             (and (null persisted)
+                  (null installed)
+                  (zerop published-count))
+             "/fast status has no persistence or runtime side effects")
+            (test-assert
+             (eq (application--builtin-fast-command application "ON")
+                 ':continue)
+             "/fast on completes through the canonical command")
+            (test-assert
+             (and (configuration-codex-fast-mode-p
+                   (application-configuration application))
+                  (equal (first persisted) '(t t))
+                  (eq (first installed) t)
+                  (= published-count 1)
+                  (search "enabled and saved" (first presented)))
+             "/fast on persists and installs the enabled state")
+            (test-assert
+             (eq (application--builtin-fast-command application "off")
+                 ':continue)
+             "/fast off completes through the canonical command")
+            (test-assert
+             (and (not
+                   (configuration-codex-fast-mode-p
+                    (application-configuration application)))
+                  (equal (first persisted) '(nil nil))
+                  (null (first installed))
+                  (= published-count 2)
+                  (search "disabled and saved" (first presented)))
+             "/fast off persists and installs the disabled state")
+            (test-assert
+             (handler-case
+                 (progn
+                   (application--builtin-fast-command application "turbo")
+                   nil)
+               (configuration-error ()
+                 t))
+             "/fast rejects unsupported modes")
+            (test-assert
+             (and (= (length persisted) 2)
+                  (= (length installed) 2)
+                  (= published-count 2))
+             "invalid /fast input has no persistence or runtime side effects")))
+      (uiop:delete-directory-tree root
+                                  :validate t
+                                  :if-does-not-exist ':ignore)))
   nil)
 
 (defclass application-authentication-test-provider (model-provider)
@@ -896,5 +999,6 @@
   (test-application-command-policies)
   (test-built-in-application-command-policies)
   (test-built-in-application-command-calls)
+  (test-application-codex-fast-mode-command)
   (test-application-authentication-command)
   t)

--- a/tests/application-command-tests.lisp
+++ b/tests/application-command-tests.lisp
@@ -585,93 +585,123 @@
          (root (test-configuration-root configuration))
          (application (make-instance 'application
                                      :configuration configuration))
+         (previous-fast-mode (uiop:getenv "AUTOLITH_CODEX_FAST_MODE"))
          (presented nil)
          (persisted nil)
          (installed nil)
          (published-count 0))
     (unwind-protect
-         (test-call-with-function-replacements
-          (list
-           (list
-            'application-present
-            (lambda (candidate entry)
-              (declare (ignore candidate))
-              (push entry presented)
-              t))
-           (list
-            'preferences-set-codex-fast-mode
-            (lambda (candidate enabled-p)
-              (push (list enabled-p
-                          (configuration-codex-fast-mode-p candidate))
-                    persisted)
-              nil))
-           (list
-            'application--install-configuration
-            (lambda (candidate replacement &key conversation)
-              (declare (ignore conversation))
-              (setf (application-configuration candidate) replacement)
-              (push (configuration-codex-fast-mode-p replacement) installed)
-              nil))
-           (list
-            'application-publish-recovery-session
-            (lambda (candidate)
-              (declare (ignore candidate))
-              (incf published-count)
-              nil)))
-          (lambda ()
-            (test-assert
-             (eq (application--builtin-fast-command application) ':continue)
-             "/fast status completes through the canonical command")
-            (test-assert
-             (search "Codex Fast mode is off." (first presented))
-             "/fast reports the disabled state")
-            (test-assert
-             (eq (application--builtin-fast-command application "status")
-                 ':continue)
-             "/fast status accepts its explicit spelling")
-            (test-assert
-             (and (null persisted)
-                  (null installed)
-                  (zerop published-count))
-             "/fast status has no persistence or runtime side effects")
-            (test-assert
-             (eq (application--builtin-fast-command application "ON")
-                 ':continue)
-             "/fast on completes through the canonical command")
-            (test-assert
-             (and (configuration-codex-fast-mode-p
-                   (application-configuration application))
-                  (equal (first persisted) '(t t))
-                  (eq (first installed) t)
-                  (= published-count 1)
-                  (search "enabled and saved" (first presented)))
-             "/fast on persists and installs the enabled state")
-            (test-assert
-             (eq (application--builtin-fast-command application "off")
-                 ':continue)
-             "/fast off completes through the canonical command")
-            (test-assert
-             (and (not
-                   (configuration-codex-fast-mode-p
-                    (application-configuration application)))
-                  (equal (first persisted) '(nil nil))
-                  (null (first installed))
-                  (= published-count 2)
-                  (search "disabled and saved" (first presented)))
-             "/fast off persists and installs the disabled state")
-            (test-assert
-             (handler-case
-                 (progn
-                   (application--builtin-fast-command application "turbo")
-                   nil)
-               (configuration-error ()
-                 t))
-             "/fast rejects unsupported modes")
-            (test-assert
-             (and (= (length persisted) 2)
-                  (= (length installed) 2)
-                  (= published-count 2))
-             "invalid /fast input has no persistence or runtime side effects")))
+         (progn
+           (sb-posix:unsetenv "AUTOLITH_CODEX_FAST_MODE")
+           (test-call-with-function-replacements
+            (list
+             (list
+              'application-present
+              (lambda (candidate entry)
+                (declare (ignore candidate))
+                (push entry presented)
+                t))
+             (list
+              'preferences-set-codex-fast-mode
+              (lambda (candidate enabled-p)
+                (push (list enabled-p
+                            (configuration-codex-fast-mode-p candidate))
+                      persisted)
+                nil))
+             (list
+              'application--install-configuration
+              (lambda (candidate replacement &key conversation)
+                (declare (ignore conversation))
+                (setf (application-configuration candidate) replacement)
+                (push (configuration-codex-fast-mode-p replacement) installed)
+                nil))
+             (list
+              'application-publish-recovery-session
+              (lambda (candidate)
+                (declare (ignore candidate))
+                (incf published-count)
+                nil)))
+            (lambda ()
+              (test-assert
+               (eq (application--builtin-fast-command application) ':continue)
+               "/fast status completes through the canonical command")
+              (test-assert
+               (search "Codex Fast mode is off." (first presented))
+               "/fast reports the disabled state")
+              (test-assert
+               (eq (application--builtin-fast-command application "status")
+                   ':continue)
+               "/fast status accepts its explicit spelling")
+              (let ((codex-configuration
+                      (application-configuration application)))
+                (setf (application-configuration application)
+                      (configuration-with-model codex-configuration "grok-4.5"))
+                (application--builtin-fast-command application "status")
+                (test-assert
+                 (and (search "preference is off" (first presented))
+                      (search "standard path" (first presented)))
+                 "/fast identifies an inactive saved preference outside Codex")
+                (setf (application-configuration application)
+                      codex-configuration))
+              (test-assert
+               (and (null persisted)
+                    (null installed)
+                    (zerop published-count))
+               "/fast status has no persistence or runtime side effects")
+              (test-assert
+               (eq (application--builtin-fast-command application "ON")
+                   ':continue)
+               "/fast on completes through the canonical command")
+              (test-assert
+               (and (configuration-codex-fast-mode-p
+                     (application-configuration application))
+                    (equal (first persisted) '(t t))
+                    (eq (first installed) t)
+                    (= published-count 1)
+                    (search "enabled and saved" (first presented)))
+               "/fast on persists and installs the enabled state")
+              (test-assert
+               (eq (application--builtin-fast-command application "off")
+                   ':continue)
+               "/fast off completes through the canonical command")
+              (test-assert
+               (and (not
+                     (configuration-codex-fast-mode-p
+                      (application-configuration application)))
+                    (equal (first persisted) '(nil nil))
+                    (null (first installed))
+                    (= published-count 2)
+                    (search "disabled and saved" (first presented)))
+               "/fast off persists and installs the disabled state")
+              (test-assert
+               (handler-case
+                   (progn
+                     (application--builtin-fast-command application "turbo")
+                     nil)
+                 (configuration-error ()
+                   t))
+               "/fast rejects unsupported modes")
+              (sb-posix:setenv "AUTOLITH_CODEX_FAST_MODE" "off" 1)
+              (application--builtin-fast-command application "status")
+              (test-assert
+               (search "AUTOLITH_CODEX_FAST_MODE controls it" (first presented))
+               "/fast status reports the process environment override")
+              (test-assert
+               (handler-case
+                   (progn
+                     (application--builtin-fast-command application "on")
+                     nil)
+                 (configuration-error ()
+                   t))
+               "/fast cannot supersede the process environment override")
+              (test-assert
+               (and (= (length persisted) 2)
+                    (= (length installed) 2)
+                    (= published-count 2))
+               "invalid or environment-controlled /fast input has no side effects"))))
+      (if previous-fast-mode
+          (sb-posix:setenv "AUTOLITH_CODEX_FAST_MODE" previous-fast-mode 1)
+          (sb-posix:unsetenv "AUTOLITH_CODEX_FAST_MODE"))
       (uiop:delete-directory-tree root
                                   :validate t
                                   :if-does-not-exist ':ignore)))

--- a/tests/application-tests.lisp
+++ b/tests/application-tests.lisp
@@ -7766,8 +7766,8 @@
                       (list
                        'configuration-create
                        (lambda (&key source-root working-directory model
-                                    reasoning-effort immutable-p
-                                    defer-provider-validation-p)
+                                    reasoning-effort codex-fast-mode-p
+                                    immutable-p defer-provider-validation-p)
                          (declare (ignore source-root
                                     defer-provider-validation-p))
                          (configuration--clone
@@ -7775,6 +7775,7 @@
                           :working-directory working-directory
                           :model model
                           :reasoning-effort reasoning-effort
+                          :codex-fast-mode-p codex-fast-mode-p
                           :immutable-p immutable-p)))
                       (list
                        'application-terminal-ui-create

--- a/tests/application-tests.lisp
+++ b/tests/application-tests.lisp
@@ -782,7 +782,7 @@
 
 (-> test-application-status-details () null)
 (defun test-application-status-details ()
-  "Test title, model, effort, and enclosing Git branch activity metadata."
+  "Test title, model, effort, Fast mode, and enclosing Git branch metadata."
   (let* ((base (test-configuration))
          (root (test-configuration-root base))
          (repository (merge-pathnames "status-repository/" root))
@@ -796,7 +796,9 @@
             (list "git" "-C" (namestring repository)
                   "symbolic-ref" "HEAD" "refs/heads/chromatic"))
             (let* ((configuration
-                     (configuration-with-working-directory base nested))
+                     (configuration-with-codex-fast-mode
+                      (configuration-with-working-directory base nested)
+                      t))
                    (conversation
                      (conversation-create configuration :identifier "status-title"))
                    (ui (terminal-ui-create
@@ -811,18 +813,26 @@
               (application-set-activity application "working")
               (let* ((details (terminal-ui-status-details ui))
                      (text (format nil "~{~A~}"
-                                   (mapcar #'terminal-span-text details))))
+                                   (mapcar #'terminal-span-text details)))
+                     (fast-span
+                       (find "FAST" details
+                             :key #'terminal-span-text
+                             :test #'string=)))
                 (test-assert
                  (string= (application--git-branch nested) "chromatic")
                  "Git branch discovery walks up from a nested workspace")
                 (test-assert
                  (search
-                  "Session title status · gpt-5.6-sol · ultra · git chromatic"
+                  "Session title status · gpt-5.6-sol · ultra · FAST · git chromatic"
                   text)
-                 "activity metadata contains the title, model, effort, and branch")
+                 "activity metadata contains title, model, effort, Fast mode, and branch")
                 (test-assert
                  (eq (terminal-span-style (second details)) ':status-accent)
                  "the session title uses the status accent style")
+                (test-assert
+                 (and fast-span
+                      (eq (terminal-span-style fast-span) ':status-accent))
+                 "active Fast mode uses the status accent")
                 (test-assert
                  (eq (terminal-span-style (first (last details)))
                      ':status-branch)

--- a/tests/context-tests.lisp
+++ b/tests/context-tests.lisp
@@ -423,14 +423,13 @@
                   (before (copy-list
                            (conversation-input-items conversation)))
                   (request (provider-request-object provider conversation #()))
-                  (input (json-get request "input"))
-                  (message (aref input (1- (length input)))))
-             (test-assert (= (length input) 4)
-                          "resolved context adds one provider-only message")
+                  (input (json-get request "input")))
              (test-assert
-              (search "Temporary context"
-                      (json-get (aref (json-get message "content") 0) "text"))
-              "request-local context is rendered after durable input")
+              (= (length input) (length before))
+              "request-local context stays outside durable provider input")
+             (test-assert
+              (search "Temporary context" (json-get request "instructions"))
+              "request-local context joins the top-level instructions")
              (test-assert
               (equal before (conversation-input-items conversation))
               "context request assembly never mutates durable conversation input"))

--- a/tests/fireworks-provider-tests.lisp
+++ b/tests/fireworks-provider-tests.lisp
@@ -115,7 +115,9 @@
 (-> fireworks-provider-test--wire-tools () null)
 (defun fireworks-provider-test--wire-tools ()
   "Test Fireworks tool flattening and item normalization round trips."
-  (let* ((namespaces
+  (let* ((provider (fireworks-provider-create
+                    (fireworks-provider-test--configuration)))
+         (namespaces
            (json-array
             (json-object
              "type" "namespace"
@@ -128,7 +130,7 @@
                        "description" "Read one file."
                        "strict" false
                        "parameters" (json-object "type" "object"))))))
-         (tools (grok-wire-tools namespaces)))
+         (tools (provider-wire-tools provider namespaces)))
     (test-assert (string= (json-get (aref tools 0) "name") "resource.read")
                  "Fireworks wire tool names join the namespace with a dot"))
   (let ((provider (fireworks-provider-create

--- a/tests/grok-provider-tests.lisp
+++ b/tests/grok-provider-tests.lisp
@@ -27,7 +27,10 @@
 (-> grok-provider-test--wire-tools () null)
 (defun grok-provider-test--wire-tools ()
   "Test namespace flattening into standard Responses function tools."
-  (let ((tools (grok-wire-tools (grok-provider-test--namespaces))))
+  (let* ((provider (grok-provider-create
+                    (grok-provider-test--configuration)))
+         (tools (provider-wire-tools
+                 provider (grok-provider-test--namespaces))))
     (test-assert (= (length tools) 2)
                  "wire tools keep one entry per tool plus passthroughs")
     (let ((flattened (aref tools 0)))
@@ -123,13 +126,15 @@
           (not (conversation-family-private-item-p
                 (json-object "type" "function_call" "call_id" "c-1"))))
      "backend search calls stay private to their producing family"))
-  (let* ((namespaced (json-object
+  (let* ((provider (grok-provider-create
+                    (grok-provider-test--configuration)))
+         (namespaced (json-object
                       "type" "function_call"
                       "call_id" "call-1"
                       "namespace" "resource"
                       "name" "read"
                       "arguments" "{}"))
-         (flattened (grok-wire-input-item namespaced)))
+         (flattened (provider-wire-input-item provider namespaced)))
     (test-assert (string= (json-get flattened "name") "resource.read")
                  "replayed function calls flatten to the dotted wire name")
     (test-assert (null (gethash "namespace" flattened))
@@ -140,7 +145,7 @@
                    "type" "function_call_output"
                    "call_id" "call-1"
                    "output" "done")))
-      (test-assert (eq (grok-wire-input-item output) output)
+      (test-assert (eq (provider-wire-input-item provider output) output)
                    "non-call input items pass through identically")))
   nil)
 

--- a/tests/preferences-tests.lisp
+++ b/tests/preferences-tests.lisp
@@ -137,6 +137,21 @@
                 (test-assert
                  (getf (rest form) :session-title-generation-p)
                  "migration enables generated session titles")))
+            (snapshot-write
+             pathname
+             '(:preferences
+               :version 2
+               :model "gpt-5.6-sol"
+               :reasoning-effort "ultra"
+               :reasoning-traces-p nil
+               :compact-view-p t))
+            (let ((version-two (preferences-load configuration)))
+              (test-assert
+               (not (preference-state-codex-fast-mode-p version-two))
+               "version two preferences without Fast mode default it to disabled")
+              (test-assert
+               (preference-state-session-title-generation-p version-two)
+               "version two preferences enable generated session titles"))
            (with-open-file (stream pathname
                                    :direction ':output
                                    :if-exists ':supersede

--- a/tests/preferences-tests.lisp
+++ b/tests/preferences-tests.lisp
@@ -152,6 +152,36 @@
               (test-assert
                (preference-state-session-title-generation-p version-two)
                "version two preferences enable generated session titles"))
+            (snapshot-write
+             pathname
+             '(:preferences
+               :version 4
+               :model nil
+               :reasoning-effort nil
+               :codex-fast-mode-p t
+               :reasoning-traces-p t
+               :compact-view-p t
+               :turn-timestamps-p nil
+               :simple-technical-english-p nil
+               :session-title-generation-p nil
+               :permission-mode nil))
+            (let ((preferences (preferences-load configuration)))
+              (test-assert
+               (preference-state-codex-fast-mode-p preferences)
+               "version four preferences preserve Codex Fast mode")
+              (test-assert
+               (preference-state-reasoning-traces-p preferences)
+               "version four preferences preserve reasoning summaries")
+              (test-assert
+               (not (preference-state-session-title-generation-p preferences))
+               "version four preferences preserve disabled title generation")
+              (multiple-value-bind (form sole-form-p)
+                  (snapshot-read pathname)
+                (test-assert sole-form-p
+                             "version four preferences remain one form")
+                (test-assert
+                 (= (getf (rest form) :version) 5)
+                 "version four preferences migrate to version five")))
            (with-open-file (stream pathname
                                    :direction ':output
                                    :if-exists ':supersede

--- a/tests/preferences-tests.lisp
+++ b/tests/preferences-tests.lisp
@@ -4,20 +4,25 @@
 
 (-> preferences-tests--without-model-environment (function) t)
 (defun preferences-tests--without-model-environment (function)
-  "Call FUNCTION while model and effort environment overrides are absent."
+  "Call FUNCTION while model, effort, and Fast mode overrides are absent."
   (let ((previous-model (uiop:getenv "AUTOLITH_MODEL"))
-        (previous-effort (uiop:getenv "AUTOLITH_REASONING_EFFORT")))
+        (previous-effort (uiop:getenv "AUTOLITH_REASONING_EFFORT"))
+        (previous-fast-mode (uiop:getenv "AUTOLITH_CODEX_FAST_MODE")))
     (unwind-protect
          (progn
            (sb-posix:unsetenv "AUTOLITH_MODEL")
            (sb-posix:unsetenv "AUTOLITH_REASONING_EFFORT")
+           (sb-posix:unsetenv "AUTOLITH_CODEX_FAST_MODE")
            (funcall function))
       (if previous-model
           (sb-posix:setenv "AUTOLITH_MODEL" previous-model 1)
           (sb-posix:unsetenv "AUTOLITH_MODEL"))
       (if previous-effort
           (sb-posix:setenv "AUTOLITH_REASONING_EFFORT" previous-effort 1)
-          (sb-posix:unsetenv "AUTOLITH_REASONING_EFFORT")))))
+          (sb-posix:unsetenv "AUTOLITH_REASONING_EFFORT"))
+      (if previous-fast-mode
+          (sb-posix:setenv "AUTOLITH_CODEX_FAST_MODE" previous-fast-mode 1)
+          (sb-posix:unsetenv "AUTOLITH_CODEX_FAST_MODE")))))
 
 (-> test-preferences () null)
 (defun test-preferences ()
@@ -32,30 +37,62 @@
                    (merge-pathnames "preferences.sexp"
                                     (configuration-state-root configuration)))
             "global preferences live under the state root")
-           (let ((preferences (preferences-load configuration)))
-             (test-assert
-              (not (preference-state-reasoning-traces-p preferences))
-              "missing preferences default reasoning summaries to hidden")
-             (test-assert (null (preference-state-model preferences))
-                          "missing preferences have no saved model")
-             (test-assert
-              (null (preference-state-reasoning-effort preferences))
-              "missing preferences have no saved reasoning effort")
-             (test-assert
-             (preference-state-compact-view-p preferences)
-              "missing preferences default to compact tool presentation")
-             (test-assert
-              (not (preference-state-turn-timestamps-p preferences))
-              "missing preferences default turn timestamps to hidden")
+            (let ((preferences (preferences-load configuration)))
+              (test-assert
+               (not (preference-state-reasoning-traces-p preferences))
+               "missing preferences default reasoning summaries to hidden")
+              (test-assert (null (preference-state-model preferences))
+                           "missing preferences have no saved model")
+              (test-assert
+               (null (preference-state-reasoning-effort preferences))
+               "missing preferences have no saved reasoning effort")
+              (test-assert
+               (not (preference-state-codex-fast-mode-p preferences))
+               "missing preferences default Codex Fast mode to disabled")
+              (test-assert
+               (preference-state-compact-view-p preferences)
+               "missing preferences default to compact tool presentation")
+              (test-assert
+               (not (preference-state-turn-timestamps-p preferences))
+               "missing preferences default turn timestamps to hidden")
+              (test-assert
+               (not (preference-state-simple-technical-english-p preferences))
+               "missing preferences default Simple Technical English to disabled")
+              (test-assert
+               (preference-state-session-title-generation-p preferences)
+               "missing preferences enable generated session titles")
+              (test-assert
+               (null (preference-state-permission-mode preferences))
+               "missing preferences have no saved command-permission mode"))
+            (preferences-tests--without-model-environment
+             (lambda ()
+               (sb-posix:setenv "AUTOLITH_CODEX_FAST_MODE" "on" 1)
+               (let ((environment-configuration
+                       (configuration-create
+                        :source-root (asdf:system-source-directory :autolith)
+                        :working-directory (asdf:system-source-directory :autolith))))
+                 (test-assert
+                  (configuration-codex-fast-mode-p environment-configuration)
+                  "the environment can enable Codex Fast mode")
+                 (test-assert
+                  (not
+                   (configuration-codex-fast-mode-p
+                    (configuration-create
+                     :source-root (asdf:system-source-directory :autolith)
+                     :working-directory (asdf:system-source-directory :autolith)
+                     :codex-fast-mode-p nil)))
+                  "an explicit Fast mode choice overrides the environment"))
+               (sb-posix:setenv "AUTOLITH_CODEX_FAST_MODE" "invalid" 1)
                (test-assert
-                (not (preference-state-simple-technical-english-p preferences))
-                "missing preferences default Simple Technical English to disabled")
-               (test-assert
-                (preference-state-session-title-generation-p preferences)
-                "missing preferences enable generated session titles")
-               (test-assert
-                (null (preference-state-permission-mode preferences))
-                "missing preferences have no saved command-permission mode"))
+                (handler-case
+                    (progn
+                      (configuration-create
+                       :source-root (asdf:system-source-directory :autolith)
+                       :working-directory (asdf:system-source-directory :autolith))
+                      nil)
+                  (configuration-error ()
+                    t))
+                "invalid Codex Fast mode environment values are rejected")))
            (ensure-directories-exist pathname)
            (snapshot-write
             pathname
@@ -66,34 +103,40 @@
               :reasoning-traces-p t
               :compact-view-p nil
               :turn-timestamps-p t))
-           (let ((preferences (preferences-load configuration)))
-             (test-assert
-              (not (preference-state-compact-view-p preferences))
-              "version three compact preferences remain readable")
-             (test-assert
-              (preference-state-turn-timestamps-p preferences)
-              "version three turn-timestamp preferences remain readable")
-             (test-assert
-              (not (preference-state-simple-technical-english-p preferences))
-              "version three preferences default Simple Technical English to disabled")
-             (multiple-value-bind (form sole-form-p)
-                 (snapshot-read pathname)
-               (test-assert sole-form-p
-                            "normalizing preferences preserves one form")
-               (test-assert (= (getf (rest form) :version) 4)
-                            "version three preferences migrate to version four")
-               (test-assert
-               (not (getf (rest form) :compact-view-p))
-                "normalizing preferences preserves compact presentation")
-               (test-assert
-                (getf (rest form) :turn-timestamps-p)
-                "normalizing preferences preserves turn-timestamp presentation")
-               (test-assert
-                (not (getf (rest form) :simple-technical-english-p))
-                "normalizing preferences adds the disabled response style")
-               (test-assert
-                (getf (rest form) :session-title-generation-p)
-                "migration enables generated session titles")))
+            (let ((preferences (preferences-load configuration)))
+              (test-assert
+               (not (preference-state-compact-view-p preferences))
+               "version three compact preferences remain readable")
+              (test-assert
+               (preference-state-turn-timestamps-p preferences)
+               "version three turn-timestamp preferences remain readable")
+              (test-assert
+               (not (preference-state-simple-technical-english-p preferences))
+               "version three preferences default Simple Technical English to disabled")
+              (test-assert
+               (not (preference-state-codex-fast-mode-p preferences))
+               "version three preferences default Codex Fast mode to disabled")
+              (multiple-value-bind (form sole-form-p)
+                  (snapshot-read pathname)
+                (test-assert sole-form-p
+                             "normalizing preferences preserves one form")
+                (test-assert (= (getf (rest form) :version) 5)
+                             "version three preferences migrate to version five")
+                (test-assert
+                 (not (getf (rest form) :compact-view-p))
+                 "normalizing preferences preserves compact presentation")
+                (test-assert
+                 (getf (rest form) :turn-timestamps-p)
+                 "normalizing preferences preserves turn-timestamp presentation")
+                (test-assert
+                 (not (getf (rest form) :simple-technical-english-p))
+                 "normalizing preferences adds the disabled response style")
+                (test-assert
+                 (not (getf (rest form) :codex-fast-mode-p))
+                 "normalizing preferences adds disabled Codex Fast mode")
+                (test-assert
+                 (getf (rest form) :session-title-generation-p)
+                 "migration enables generated session titles")))
            (with-open-file (stream pathname
                                    :direction ':output
                                    :if-exists ':supersede
@@ -104,55 +147,82 @@
                       :reasoning-traces-p t)
                     stream)
              (terpri stream))
-           (let ((legacy (preferences-load configuration)))
-             (test-assert
-              (preference-state-reasoning-traces-p legacy)
-              "version one reasoning-summary preferences remain readable")
-             (test-assert (null (preference-state-model legacy))
-                          "version one preferences have no saved model")
-             (test-assert
-              (preference-state-compact-view-p legacy)
-              "version one preferences default to compact tool presentation")
-             (test-assert
-              (not (preference-state-turn-timestamps-p legacy))
-              "version one preferences default turn timestamps to hidden")
-             (test-assert
-              (not (preference-state-simple-technical-english-p legacy))
-              "version one preferences default Simple Technical English to disabled")
-             (test-assert
-              (preference-state-session-title-generation-p legacy)
-              "version one preferences enable generated session titles"))
-           (let* ((selected
-                    (configuration-with-reasoning-effort
-                     (configuration-with-model configuration "gpt-5.6-luna")
-                     "high")))
-             (preferences-set-model-selection selected)
-             (let ((preferences (preferences-load configuration)))
-               (test-assert
-                (string= (preference-state-model preferences) "gpt-5.6-luna")
-                "the selected model survives a preference reload")
-               (test-assert
-                (string= (preference-state-reasoning-effort preferences) "high")
-                "the selected reasoning effort survives a preference reload")
-               (test-assert
-                (preference-state-reasoning-traces-p preferences)
-                "saving model choices preserves the trace preference")
-               (test-assert
-               (preference-state-compact-view-p preferences)
-                "saving model choices preserves compact presentation")
-               (test-assert
-                (not (preference-state-turn-timestamps-p preferences))
-                "saving model choices preserves hidden turn timestamps"))
-             (preferences-tests--without-model-environment
-              (lambda ()
-                (let ((restored
-                        (preferences-apply-model-selection configuration)))
-                  (test-assert
-                   (string= (configuration-model restored) "gpt-5.6-luna")
-                   "saved models become startup defaults")
-                  (test-assert
-                   (string= (configuration-reasoning-effort restored) "high")
-                   "saved efforts become startup defaults")))))
+            (let ((legacy (preferences-load configuration)))
+              (test-assert
+               (preference-state-reasoning-traces-p legacy)
+               "version one reasoning-summary preferences remain readable")
+              (test-assert (null (preference-state-model legacy))
+                           "version one preferences have no saved model")
+              (test-assert
+               (preference-state-compact-view-p legacy)
+               "version one preferences default to compact tool presentation")
+              (test-assert
+               (not (preference-state-turn-timestamps-p legacy))
+               "version one preferences default turn timestamps to hidden")
+              (test-assert
+               (not (preference-state-simple-technical-english-p legacy))
+               "version one preferences default Simple Technical English to disabled")
+              (test-assert
+               (not (preference-state-codex-fast-mode-p legacy))
+               "version one preferences default Codex Fast mode to disabled")
+              (test-assert
+               (preference-state-session-title-generation-p legacy)
+               "version one preferences enable generated session titles"))
+            (let* ((selected
+                     (configuration-with-reasoning-effort
+                      (configuration-with-model configuration "gpt-5.6-luna")
+                      "high")))
+              (preferences-set-model-selection selected)
+              (preferences-set-codex-fast-mode selected t)
+              (let ((preferences (preferences-load configuration)))
+                (test-assert
+                 (string= (preference-state-model preferences) "gpt-5.6-luna")
+                 "the selected model survives a preference reload")
+                (test-assert
+                 (string= (preference-state-reasoning-effort preferences) "high")
+                 "the selected reasoning effort survives a preference reload")
+                (test-assert
+                 (preference-state-codex-fast-mode-p preferences)
+                 "Codex Fast mode survives a preference reload")
+                (test-assert
+                 (preference-state-reasoning-traces-p preferences)
+                 "saving model choices preserves the trace preference")
+                (test-assert
+                 (preference-state-compact-view-p preferences)
+                 "saving model choices preserves compact presentation")
+                (test-assert
+                 (not (preference-state-turn-timestamps-p preferences))
+                 "saving model choices preserves hidden turn timestamps"))
+              (preferences-tests--without-model-environment
+               (lambda ()
+                 (let ((restored
+                         (preferences-apply-model-selection configuration)))
+                   (test-assert
+                    (string= (configuration-model restored) "gpt-5.6-luna")
+                    "saved models become startup defaults")
+                   (test-assert
+                    (string= (configuration-reasoning-effort restored) "high")
+                    "saved efforts become startup defaults")
+                   (test-assert
+                    (configuration-codex-fast-mode-p restored)
+                    "saved Codex Fast mode becomes the startup default")))))
+           (preferences-tests--without-model-environment
+            (lambda ()
+              (sb-posix:setenv "AUTOLITH_CODEX_FAST_MODE" "off" 1)
+              (test-assert
+               (not
+                (configuration-codex-fast-mode-p
+                 (preferences-apply-model-selection
+                  (configuration-with-codex-fast-mode configuration nil))))
+               "the environment can disable saved Codex Fast mode")
+              (preferences-set-codex-fast-mode configuration nil)
+              (sb-posix:setenv "AUTOLITH_CODEX_FAST_MODE" "on" 1)
+              (test-assert
+               (configuration-codex-fast-mode-p
+                (preferences-apply-model-selection
+                 (configuration-with-codex-fast-mode configuration t)))
+               "the environment can enable Codex Fast mode over a saved default")
+              (preferences-set-codex-fast-mode configuration t)))
            (let ((mode (sb-posix:stat-mode
                         (sb-posix:stat (namestring pathname)))))
              (test-assert (= (logand mode #o777) #o600)

--- a/tests/provider-tests.lisp
+++ b/tests/provider-tests.lisp
@@ -153,13 +153,13 @@
 
 (-> provider-tests--request-tools (json-object) vector)
 (defun provider-tests--request-tools (request)
-  "Return the tools from REQUEST's leading additional-tools item."
-  (json-get (aref (json-get request "input") 0) "tools"))
+  "Return REQUEST's top-level standard Responses tools."
+  (json-get request "tools"))
 
 (-> provider-tests--request-tool-of-type
     (json-object string) (option json-object))
 (defun provider-tests--request-tool-of-type (request type)
-  "Return REQUEST's first additional tool whose type equals TYPE."
+  "Return REQUEST's first standard Responses tool whose type equals TYPE."
   (find type
         (provider-tests--request-tools request)
         :key (lambda (tool)
@@ -169,7 +169,7 @@
 
 (-> test-provider-request () null)
 (defun test-provider-request ()
-  "Test the Sol Responses Lite request shape without network access."
+  "Test the standard Codex Responses request shape without network access."
   (let* ((base-configuration (test-configuration))
          (root (test-configuration-root base-configuration))
          (configuration
@@ -184,7 +184,12 @@
                            "type" "namespace"
                            "name" "test"
                            "description" "Test tools."
-                           "tools" (json-array))))
+                           "tools"
+                           (json-array
+                            (json-object
+                             "name" "inspect"
+                             "description" "Inspect a value."
+                             "parameters" (json-object "type" "object"))))))
                 (request nil))
            (conversation-append-user-message conversation "hello")
            (setf request (provider-request-object provider conversation schemas))
@@ -194,6 +199,8 @@
             (not (provider-child-reference-history-p
                   (make-instance 'model-provider)))
             "providers opt into inherited child reference history explicitly")
+           (test-assert (eq (provider-wire-protocol provider) ':responses-api)
+                        "Codex reports the standard Responses API protocol")
            (test-assert (null (json-get request "service_tier"))
                         "standard Codex requests omit the service tier")
            (dolist (model *codex-fast-mode-models*)
@@ -235,37 +242,29 @@
              (test-assert (null (json-get bounded "max_output_tokens"))
                           "the Codex serving stack never receives an output ceiling"))
            (let ((input (json-get request "input")))
-             (test-assert (= (length input) 3)
-                          "the provider request prefixes two developer items")
              (test-assert
-              (string= (json-get (aref input 0) "type") "additional_tools")
-              "additional tools are the first input item")
-             (test-assert
-              (null (provider-tests--request-tool-of-type request "web_search"))
-              "requests omit the nonfunctional native web search tool")
-             (test-assert
-              (string= (json-get (aref input 1) "role") "developer")
-              "the Autolith system prompt is the second input item")
-             (test-assert (string= (json-get (aref input 2) "role") "user")
-                          "conversation history follows the developer prefix"))
+              (and (= (length input) 1)
+                   (string= (json-get (aref input 0) "role") "user"))
+              "standard Responses input begins with conversation history"))
+           (test-assert
+            (non-empty-string-p (json-get request "instructions"))
+            "standard Responses uses top-level instructions")
            (let* ((goal-request
                     (provider-request-object
                      provider conversation schemas
                      :goal-context "<goal_context>persist</goal_context>"))
-                  (goal-input (json-get goal-request "input"))
-                  (goal-message (aref goal-input 2)))
-             (test-assert (= (length goal-input) 4)
-                          "an active goal adds one transient developer message")
-             (test-assert (string= (json-get goal-message "role") "developer")
-                          "the goal context is a developer message")
+                  (goal-input (json-get goal-request "input")))
+             (test-assert (= (length goal-input) 1)
+                          "goal context stays outside durable conversation input")
              (test-assert
-              (search "<goal_context>"
-                      (json-get (aref (json-get goal-message "content") 0)
-                                "text"))
-              "the goal context rides as developer text"))
+              (search "<goal_context>" (json-get goal-request "instructions"))
+              "goal context joins the top-level instructions"))
            (test-assert
             (null (provider-web-search-tool configuration))
             "the nonfunctional native web search tool stays disabled")
+           (test-assert
+            (null (provider-tests--request-tool-of-type request "web_search"))
+            "requests omit the nonfunctional native web search tool")
            (test-assert
             (string= (json-get (json-get request "reasoning") "effort") "max")
             "the provider request maps Ultra reasoning to Max")
@@ -322,14 +321,10 @@
                (test-assert
                 (provider-reasoning-summaries-p reconfigured)
                 "provider reconfiguration preserves the trace preference")))
-           (test-assert
-            (string= (json-get (json-get request "reasoning") "context")
-                     "all_turns")
-            "the provider request retains reasoning across the current context")
            (test-assert (string= (json-get request "tool_choice") "auto")
                         "the provider request permits automatic tool selection")
-           (test-assert (eq (json-get request "parallel_tool_calls") false)
-                        "the provider request disables parallel tool calls")
+           (test-assert (eq (json-get request "parallel_tool_calls") t)
+                        "normal standard requests enable parallel tool calls")
            (test-assert (eq (json-get request "store") false)
                         "the provider request disables server-side storage")
            (test-assert (eq (json-get request "stream") t)
@@ -374,16 +369,36 @@
            (test-assert
             (string= (json-get (json-get request "text") "verbosity") "low")
             "the provider request asks for restrained text verbosity")
-           (multiple-value-bind (value present-p)
-               (gethash "instructions" request)
-             (declare (ignore value))
-             (test-assert (not present-p)
-                          "Responses Lite omits top-level instructions"))
-           (multiple-value-bind (value present-p)
-               (gethash "tools" request)
-             (declare (ignore value))
-             (test-assert (not present-p)
-                          "Responses Lite omits top-level tools")))
+           (let ((tools (provider-tests--request-tools request)))
+             (test-assert
+              (and (= (length tools) 1)
+                   (string= (json-get (aref tools 0) "name")
+                            (responses-standard-tool-name "test" "inspect"))
+                   (every (lambda (character)
+                            (or (alphanumericp character)
+                                (find character "_-")))
+                          (json-get (aref tools 0) "name")))
+              "standard Responses uses a grammar-safe flattened tool name"))
+           (let ((compaction-request
+                   (provider-request-object
+                    provider conversation schemas :compaction-p t)))
+             (test-assert
+              (and (eq (json-get compaction-request "parallel_tool_calls") false)
+                   (zerop (length (json-get compaction-request "tools")))
+                   (search "context checkpoint compaction"
+                           (json-get compaction-request "instructions")))
+              "portable compaction fallback is tool-free and serial"))
+           (let ((normalized
+                   (provider-normalize-output-item
+                    provider
+                    (json-object
+                     "type" "function_call"
+                     "name" (responses-standard-tool-name "test" "inspect")
+                     "call_id" "call-standard"))))
+             (test-assert
+              (and (string= (json-get normalized "namespace") "test")
+                   (string= (json-get normalized "name") "inspect"))
+              "standard Codex output restores the local tool namespace")))
       (uiop:delete-directory-tree root :validate t :if-does-not-exist ':ignore)))
   nil)
 
@@ -416,87 +431,55 @@
                          "call_id" "ephemeral-call"
                          "name" "test")
             :persistence ':next-response)
-           (let* ((request
-                    (provider-native-compaction-request-object
-                     provider conversation schemas))
-                  (input (json-get request "input")))
-             (test-assert (= (length input) 4)
-                          "native compaction carries prefix and durable history")
-             (test-assert
-              (string= (json-get (aref input 0) "type") "additional_tools")
-              "native compaction retains the Responses Lite tool prefix")
-             (test-assert
-              (null (provider-tests--request-tool-of-type request "web_search"))
-              "native compaction omits the nonfunctional web search tool")
-             (test-assert
-              (find "test"
-                    (provider-tests--request-tools request)
-                    :key (lambda (tool) (json-get tool "name"))
-                    :test #'equal)
-              "ordinary native compaction retains namespace schemas")
-
-             (test-assert
-              (string= (json-get (aref input 1) "role") "developer")
-              "native compaction retains the system developer message")
-             (test-assert
-              (and (reasoning-item-p (aref input 3))
-                   (string= (json-get (aref input 3) "encrypted_content")
-                            "retained-reasoning"))
-              "native compaction carries retained encrypted reasoning")
-             (test-assert
-              (not (find-if
-                    (lambda (item)
-                      (string= (or (json-get item "type") "")
-                               "compaction_trigger"))
-                    (coerce input 'list)))
-              "native compaction leaves the endpoint to select its own trigger")
-             (test-assert
-              (string= (json-get (json-get request "reasoning") "context")
-                       "all_turns")
-              "native compaction retains reasoning across its input")
-             (test-assert
-              (string= (json-get request "prompt_cache_key")
-                       (conversation-prompt-cache-key conversation))
-              "native compaction shares the root conversation cache key")
-             (test-assert (null (json-get request "service_tier"))
-                          "standard native compaction omits a service tier")
-             (let* ((fast-configuration
-                      (configuration-with-codex-fast-mode configuration t))
-                    (fast-provider (provider-create fast-configuration))
-                    (fast-request
-                      (provider-native-compaction-request-object
-                       fast-provider conversation schemas)))
-               (test-assert
-                (string= (json-get fast-request "service_tier") "priority")
-                "Codex Fast mode applies to native compaction"))
-             (let* ((unknown-configuration
-                      (configuration-with-codex-fast-mode
-                       (configuration--clone configuration
-                                             :model "gpt-future-unknown")
-                       t))
-                    (unknown-provider (provider-create unknown-configuration))
-                    (unknown-request
-                      (provider-native-compaction-request-object
-                       unknown-provider conversation schemas)))
-               (test-assert
-                (null (json-get unknown-request "service_tier"))
-                "unknown Codex models omit Fast mode during compaction"))
-             (dolist (name '("stream" "store" "include" "tool_choice"))
-               (multiple-value-bind (value present-p) (gethash name request)
-                 (declare (ignore value))
-                 (test-assert (not present-p)
-                              (format nil "native compaction omits ~A" name)))))
-           (setf (provider-reasoning-summaries-p provider) t)
-           (test-assert
-            (string= (json-get
-                      (json-get
+            (let* ((request
+                     (provider-native-compaction-request-object
+                      provider conversation schemas))
+                   (input (json-get request "input")))
+              (test-assert
+               (and (= (length input) 2)
+                    (string= (json-get (aref input 0) "role") "user"))
+               "native compaction carries durable standard Responses input")
+              (test-assert
+               (and (reasoning-item-p (aref input 1))
+                    (string= (json-get (aref input 1) "encrypted_content")
+                             "retained-reasoning"))
+               "native compaction carries retained encrypted reasoning")
+              (test-assert
+               (non-empty-string-p (json-get request "instructions"))
+               "native compaction uses top-level instructions")
+              (test-assert
+               (string= (json-get request "prompt_cache_key")
+                        (conversation-prompt-cache-key conversation))
+               "native compaction shares the root conversation cache key")
+              (test-assert (null (json-get request "service_tier"))
+                           "standard native compaction omits a service tier")
+              (let* ((fast-configuration
+                       (configuration-with-codex-fast-mode configuration t))
+                     (fast-provider (provider-create fast-configuration))
+                     (fast-request
                        (provider-native-compaction-request-object
-                        provider conversation schemas)
-                       "reasoning")
-                      "summary")
-                     "auto")
-            "native compaction preserves enabled reasoning summaries")
-           (setf (provider-reasoning-summaries-p provider) nil)
+                        fast-provider conversation schemas)))
+                (test-assert
+                 (string= (json-get fast-request "service_tier") "priority")
+                 "Codex Fast mode applies to native compaction"))
+              (let* ((unknown-configuration
+                       (configuration-with-codex-fast-mode
+                        (configuration--clone configuration
+                                              :model "gpt-future-unknown")
+                        t))
+                     (unknown-provider (provider-create unknown-configuration))
+                     (unknown-request
+                       (provider-native-compaction-request-object
+                        unknown-provider conversation schemas)))
+                (test-assert
+                 (null (json-get unknown-request "service_tier"))
+                 "unknown Codex models omit Fast mode during compaction"))
+              (dolist (name '("stream" "store" "include" "tool_choice"
+                              "parallel_tool_calls" "reasoning" "text" "tools"))
+                (multiple-value-bind (value present-p) (gethash name request)
+                  (declare (ignore value))
+                  (test-assert (not present-p)
+                               (format nil "native compaction omits ~A" name)))))
            (let ((captured-url nil)
                  (captured-headers nil)
                  (captured-content nil))

--- a/tests/provider-tests.lisp
+++ b/tests/provider-tests.lisp
@@ -199,8 +199,10 @@
             (not (provider-child-reference-history-p
                   (make-instance 'model-provider)))
             "providers opt into inherited child reference history explicitly")
+           (test-assert (typep provider 'responses-api-provider)
+                        "Codex uses the shared Responses provider representation")
            (test-assert (eq (provider-wire-protocol provider) ':responses-api)
-                        "Codex reports the standard Responses API protocol")
+                        "Codex inherits the standard Responses API protocol")
            (test-assert (null (json-get request "service_tier"))
                         "standard Codex requests omit the service tier")
            (dolist (model *codex-fast-mode-models*)
@@ -241,6 +243,19 @@
                                                      schemas))))
              (test-assert (null (json-get bounded "max_output_tokens"))
                           "the Codex serving stack never receives an output ceiling"))
+           (let* ((wire-fields
+                    (apply #'json-object
+                           (provider-responses-request-fields
+                            provider conversation)))
+                  (field-names
+                    '("parallel_tool_calls" "include"
+                      "prompt_cache_key" "text")))
+             (test-assert
+              (every (lambda (name)
+                       (equalp (json-get request name)
+                               (json-get wire-fields name)))
+                     field-names)
+              "Codex's generic Responses fields match the concrete request"))
            (let ((input (json-get request "input")))
              (test-assert
               (and (= (length input) 1)
@@ -369,16 +384,14 @@
            (test-assert
             (string= (json-get (json-get request "text") "verbosity") "low")
             "the provider request asks for restrained text verbosity")
-           (let ((tools (provider-tests--request-tools request)))
+           (let* ((tools (provider-tests--request-tools request))
+                  (wire-name
+                    (provider-wire-tool-name provider "test" "inspect")))
              (test-assert
               (and (= (length tools) 1)
-                   (string= (json-get (aref tools 0) "name")
-                            (responses-standard-tool-name "test" "inspect"))
-                   (every (lambda (character)
-                            (or (alphanumericp character)
-                                (find character "_-")))
-                          (json-get (aref tools 0) "name")))
-              "standard Responses uses a grammar-safe flattened tool name"))
+                   (string= (json-get (aref tools 0) "name") wire-name)
+                   (provider-wire-function-name--valid-p wire-name))
+              "standard Responses uses the shared grammar-safe tool codec"))
            (let ((compaction-request
                    (provider-request-object
                     provider conversation schemas :compaction-p t)))
@@ -388,17 +401,23 @@
                    (search "context checkpoint compaction"
                            (json-get compaction-request "instructions")))
               "portable compaction fallback is tool-free and serial"))
-           (let ((normalized
-                   (provider-normalize-output-item
-                    provider
+           (let* ((local-call
                     (json-object
                      "type" "function_call"
-                     "name" (responses-standard-tool-name "test" "inspect")
-                     "call_id" "call-standard"))))
+                     "namespace" "test"
+                     "name" "inspect"
+                     "call_id" "call-standard"))
+                  (wire-call (provider-wire-input-item provider local-call))
+                  (normalized
+                    (provider-normalize-output-item
+                     provider (json-object-copy wire-call))))
              (test-assert
-              (and (string= (json-get normalized "namespace") "test")
+              (and (null (json-get wire-call "namespace"))
+                   (provider-wire-function-name--valid-p
+                    (json-get wire-call "name"))
+                   (string= (json-get normalized "namespace") "test")
                    (string= (json-get normalized "name") "inspect"))
-              "standard Codex output restores the local tool namespace")))
+              "Codex wire hooks round-trip the local tool namespace")))
       (uiop:delete-directory-tree root :validate t :if-does-not-exist ':ignore)))
   nil)
 

--- a/tests/provider-tests.lisp
+++ b/tests/provider-tests.lisp
@@ -195,16 +195,38 @@
                   (make-instance 'model-provider)))
             "providers opt into inherited child reference history explicitly")
            (test-assert (null (json-get request "service_tier"))
-                        "requests never select a provider service tier")
-            (let* ((fast-configuration
-                     (configuration-with-codex-fast-mode configuration t))
-                   (fast-provider (provider-create fast-configuration))
-                   (fast-request
-                     (provider-request-object
-                      fast-provider conversation schemas)))
-              (test-assert
-               (string= (json-get fast-request "service_tier") "fast")
-               "Codex Fast mode requests the fast service tier"))
+                        "standard Codex requests omit the service tier")
+           (dolist (model *codex-fast-mode-models*)
+             (let* ((fast-configuration
+                      (configuration-with-codex-fast-mode
+                       (configuration--clone configuration :model model)
+                       t))
+                    (fast-provider (provider-create fast-configuration))
+                    (fast-request
+                      (provider-request-object
+                       fast-provider conversation schemas)))
+               (test-assert
+                (and (configuration-codex-fast-mode-available-p
+                      fast-configuration)
+                     (configuration-codex-fast-mode-active-p
+                      fast-configuration)
+                     (string= (json-get fast-request "service_tier") "fast"))
+                (format nil "~A advertises and requests Codex Fast mode" model))))
+           (let* ((unknown-configuration
+                    (configuration-with-codex-fast-mode
+                     (configuration--clone configuration
+                                           :model "gpt-future-unknown")
+                     t))
+                  (unknown-provider (provider-create unknown-configuration))
+                  (unknown-request
+                    (provider-request-object
+                     unknown-provider conversation schemas)))
+             (test-assert
+              (and (configuration-codex-fast-mode-p unknown-configuration)
+                   (not (configuration-codex-fast-mode-active-p
+                         unknown-configuration))
+                   (null (json-get unknown-request "service_tier")))
+              "unknown Codex models use the standard service tier"))
            (test-assert (null (json-get request "max_output_tokens"))
                         "requests omit the output ceiling when none is bound")
            (let ((bounded (let ((*provider-maximum-output-tokens* 4242))
@@ -436,17 +458,29 @@
               (string= (json-get request "prompt_cache_key")
                        (conversation-prompt-cache-key conversation))
               "native compaction shares the root conversation cache key")
-              (test-assert (null (json-get request "service_tier"))
-                           "standard native compaction omits a service tier")
-              (let* ((fast-configuration
-                       (configuration-with-codex-fast-mode configuration t))
-                     (fast-provider (provider-create fast-configuration))
-                     (fast-request
-                       (provider-native-compaction-request-object
-                        fast-provider conversation schemas)))
-                (test-assert
-                 (string= (json-get fast-request "service_tier") "fast")
-                 "Codex Fast mode applies to native compaction"))
+             (test-assert (null (json-get request "service_tier"))
+                          "standard native compaction omits a service tier")
+             (let* ((fast-configuration
+                      (configuration-with-codex-fast-mode configuration t))
+                    (fast-provider (provider-create fast-configuration))
+                    (fast-request
+                      (provider-native-compaction-request-object
+                       fast-provider conversation schemas)))
+               (test-assert
+                (string= (json-get fast-request "service_tier") "fast")
+                "Codex Fast mode applies to native compaction"))
+             (let* ((unknown-configuration
+                      (configuration-with-codex-fast-mode
+                       (configuration--clone configuration
+                                             :model "gpt-future-unknown")
+                       t))
+                    (unknown-provider (provider-create unknown-configuration))
+                    (unknown-request
+                      (provider-native-compaction-request-object
+                       unknown-provider conversation schemas)))
+               (test-assert
+                (null (json-get unknown-request "service_tier"))
+                "unknown Codex models omit Fast mode during compaction"))
              (dolist (name '("stream" "store" "include" "tool_choice"))
                (multiple-value-bind (value present-p) (gethash name request)
                  (declare (ignore value))

--- a/tests/provider-tests.lisp
+++ b/tests/provider-tests.lisp
@@ -210,7 +210,7 @@
                       fast-configuration)
                      (configuration-codex-fast-mode-active-p
                       fast-configuration)
-                     (string= (json-get fast-request "service_tier") "fast"))
+                     (string= (json-get fast-request "service_tier") "priority"))
                 (format nil "~A advertises and requests Codex Fast mode" model))))
            (let* ((unknown-configuration
                     (configuration-with-codex-fast-mode
@@ -467,7 +467,7 @@
                       (provider-native-compaction-request-object
                        fast-provider conversation schemas)))
                (test-assert
-                (string= (json-get fast-request "service_tier") "fast")
+                (string= (json-get fast-request "service_tier") "priority")
                 "Codex Fast mode applies to native compaction"))
              (let* ((unknown-configuration
                       (configuration-with-codex-fast-mode

--- a/tests/provider-tests.lisp
+++ b/tests/provider-tests.lisp
@@ -196,6 +196,15 @@
             "providers opt into inherited child reference history explicitly")
            (test-assert (null (json-get request "service_tier"))
                         "requests never select a provider service tier")
+            (let* ((fast-configuration
+                     (configuration-with-codex-fast-mode configuration t))
+                   (fast-provider (provider-create fast-configuration))
+                   (fast-request
+                     (provider-request-object
+                      fast-provider conversation schemas)))
+              (test-assert
+               (string= (json-get fast-request "service_tier") "fast")
+               "Codex Fast mode requests the fast service tier"))
            (test-assert (null (json-get request "max_output_tokens"))
                         "requests omit the output ceiling when none is bound")
            (let ((bounded (let ((*provider-maximum-output-tokens* 4242))
@@ -427,6 +436,17 @@
               (string= (json-get request "prompt_cache_key")
                        (conversation-prompt-cache-key conversation))
               "native compaction shares the root conversation cache key")
+              (test-assert (null (json-get request "service_tier"))
+                           "standard native compaction omits a service tier")
+              (let* ((fast-configuration
+                       (configuration-with-codex-fast-mode configuration t))
+                     (fast-provider (provider-create fast-configuration))
+                     (fast-request
+                       (provider-native-compaction-request-object
+                        fast-provider conversation schemas)))
+                (test-assert
+                 (string= (json-get fast-request "service_tier") "fast")
+                 "Codex Fast mode applies to native compaction"))
              (dolist (name '("stream" "store" "include" "tool_choice"))
                (multiple-value-bind (value present-p) (gethash name request)
                  (declare (ignore value))


### PR DESCRIPTION
## Description

Codex can return several independent function calls in one Responses turn. This change enables that provider capability and executes safe calls concurrently instead of serially.

The agent plans the complete call batch, partitions it into ordered waves, executes each independent wave with a bounded worker pool, and records every call result in the provider's original wire order. Provider round-trip barriers, exclusive tools, duplicate mutable-runtime keys, shell commands, Lisp workers, and active-image mutations run in separate serialized waves.

The Codex transport now uses the standard Responses request shape. Instructions and flattened function tools use their standard top-level fields, normal requests set `parallel_tool_calls: true`, and responses continue streaming over SSE. Native context checkpointing remains on `/responses/compact` with the standard compaction payload. These transport changes apply only to the Codex provider.

## Behavior

- add configurable Codex Fast mode using `service_tier: priority`
- stream assistant text and reasoning-summary deltas as they arrive
- enable parallel tool calls on normal Codex requests
- keep compaction tool-free and serial
- preserve deterministic provider wire order for persisted calls and results
- stop later calls after a provider round-trip barrier
- serialize tools sharing mutable runtime state

## Testing

- focused context, provider request, native compaction, parallel wave, shared-runtime, exclusive-wave, and parallel failure tests pass
- delimiter checks pass for `src` and `tests`
- `./script/check` reaches the unchanged release tests, then fails because the Linux-only `cl-exec-sandbox` helper is absent on macOS at `release-script-tests--archive-helpers`
