### PR TITLE
Show live context window usage

### DIFF
--- a/docs/guide.org
+++ b/docs/guide.org
@@ -248,6 +248,17 @@ eventually disappear:
 Note that these are provider-request-only, and don't not count as a conversation turn,
 and do not get attached to your messages.
 
+The status line keeps a context meter visible while idle. It shows used tokens
+and the full model window. =|= marks the automatic compaction point. The
+ChatGPT subscription catalog currently reports a 272K-token window for GPT-5.6
+Sol, Luna, and Terra, which compact at about 218K tokens by default:
+
+#+BEGIN_EXAMPLE
+ctx [==========|..] 218K / 272K used
+#+END_EXAMPLE
+
+At narrow widths, the meter keeps the used and window counts and drops the bar.
+
 ** Providers
 
 Register a OpenAI-compatible provider:

--- a/src/application/runtime.lisp
+++ b/src/application/runtime.lisp
@@ -735,6 +735,7 @@ model's effort choice to CONFIGURATION--CLONE."
                        (application-provider application) new-provider
                        (application-tool-registry application) new-registry
                        (application-agent application) new-agent)
+                  (application-refresh-context-meter application)
                  (application-connect-task-presentation application)
                  (context-runtime-reset)
                  (setf committed-p t))
@@ -750,7 +751,8 @@ model's effort choice to CONFIGURATION--CLONE."
             (setf (application-configuration application) old-configuration
                   (application-provider application) old-provider
                   (application-tool-registry application) old-registry
-                  (application-agent application) old-agent))
+                  (application-agent application) old-agent)
+            (application-refresh-context-meter application))
           (application--extension-registry-restore
            extension-registry-snapshot)
           (when new-registry
@@ -998,6 +1000,7 @@ newly acquired lease."
                            nil
                            (application-history-floor-sequence application)
                            restored-history-floor-sequence))
+                          (application-refresh-context-meter application)
                         (application-connect-task-presentation application)
                         (application--load-goal application)
                         (application-publish-recovery-session application)
@@ -1201,6 +1204,7 @@ newly acquired lease."
                 (application-history-floor-sequence new-application)
                 restored-history-floor-sequence
                 (application-mutation-replay-failures new-application) nil))
+              (application-refresh-context-meter new-application)
              (application--load-goal new-application)
              (image-state-reconnect)
              (setf retirement-started-p t
@@ -1290,6 +1294,24 @@ newly acquired lease."
         (application-update-check-thread application) nil)
   application)
 
+(-> application-refresh-context-meter (application) null)
+(defun application-refresh-context-meter (application)
+  "Refresh APPLICATION's persistent context meter from its active runtime."
+  (when (and (slot-boundp application 'ui)
+             (slot-boundp application 'configuration)
+             (slot-boundp application 'conversation))
+    (let ((ui (application-ui application)))
+      (when ui
+        (let ((configuration (application-configuration application)))
+          (terminal-ui-set-context-usage
+           ui
+           :used (conversation-last-total-tokens
+                  (application-conversation application))
+           :window (configuration-context-window configuration)
+           :compaction-limit
+           (configuration-compaction-token-limit configuration))))))
+  nil)
+
 (-> application--install-configuration
     (application configuration &key (:conversation (option conversation)))
     null)
@@ -1313,6 +1335,7 @@ newly acquired lease."
           (application-conversation application) active-conversation
           (application-provider application) provider
           (application-agent application) agent))
+  (application-refresh-context-meter application)
   nil)
 
 (-> application--agent-adopt-runtime (application agent) null)
@@ -1463,6 +1486,7 @@ command replaced the active conversation."
                        (application-provider application) provider
                        (application-tool-registry application) registry
                        (application-agent application) agent)
+                  (application-refresh-context-meter application)
                  (application-connect-task-presentation application)
                  (context-runtime-reset)
                  (setf committed-p t))
@@ -1488,7 +1512,8 @@ command replaced the active conversation."
                   (application-tool-registry application)
                   previous-registry
                   (application-agent application)
-                  previous-agent))
+                  previous-agent)
+            (application-refresh-context-meter application))
           (when process-moved-p
             (handler-case
                 (progn
@@ -1694,6 +1719,7 @@ command replaced the active conversation."
                (not
                 (eq previous-conversation-lease conversation-lease)))
       (conversation-lease-release previous-conversation-lease))
+    (application-refresh-context-meter application)
     application))
 
 (-> application-install-conversation (application conversation) application)
@@ -2740,6 +2766,7 @@ remain finalized so later conversation replay cannot duplicate streamed rows."
 (-> application-set-activity (application (option string)) terminal-ui)
 (defun application-set-activity (application status)
   "Set APPLICATION's live STATUS and snapshot its contextual details once."
+  (application-refresh-context-meter application)
   (terminal-ui-set-status
    (application-ui application)
    status
@@ -3003,6 +3030,7 @@ remain finalized so later conversation replay cannot duplicate streamed rows."
                              (getf details :attempt)
                              (getf details :maximum-attempts)))))))
            (:provider-request-completed
+            (application-refresh-context-meter application)
             (reasoning-flush)
             (let ((completed-stream-text
                     (and stream-open-p (text-buffer-string stream-text)))

--- a/src/terminal/protocol.lisp
+++ b/src/terminal/protocol.lisp
@@ -221,6 +221,21 @@
     :accessor terminal-ui-status
     :type (option string)
     :documentation "The optional unfinished activity shown above the prompt.")
+   (context-used
+    :initform nil
+    :accessor terminal-ui-context-used
+    :type (option (integer 0))
+    :documentation "The newest provider-reported context usage in tokens.")
+   (context-window
+    :initform nil
+    :accessor terminal-ui-context-window
+    :type (option (integer 1))
+    :documentation "The active model's context window in tokens.")
+   (context-compaction-limit
+    :initform nil
+    :accessor terminal-ui-context-compaction-limit
+    :type (option (integer 1))
+    :documentation "The context usage at which automatic compaction begins.")
    (compacting-p
     :initform nil
     :accessor terminal-ui-compacting-p

--- a/src/terminal/ui.lisp
+++ b/src/terminal/ui.lisp
@@ -13,6 +13,9 @@
 (defparameter *terminal-ui-status-spinner-frames-per-second* 4
   "The number of live status animation frames painted each second.")
 
+(defparameter *terminal-ui-context-track-cells* 12
+  "The preferred number of context-capacity cells beside the compaction marker.")
+
 (defparameter *terminal-ui-compaction-track-cells* 32
   "The maximum width of the indeterminate compaction track.")
 
@@ -1176,9 +1179,9 @@ columns: name, tally, and description."
      :key (lambda (activity)
             (getf activity :index)))))
 
-(-> terminal-ui--status-row-visible-p (terminal-ui) boolean)
-(defun terminal-ui--status-row-visible-p (ui)
-  "Return whether UI needs its animated status row above live activity."
+(-> terminal-ui--animated-status-row-p (terminal-ui) boolean)
+(defun terminal-ui--animated-status-row-p (ui)
+  "Return whether UI has live activity needing an animated status row."
   (not
    (null
     (or (terminal-ui-status ui)
@@ -1188,6 +1191,14 @@ columns: name, tally, and description."
         (terminal-ui-agent-activities ui)
         (terminal-ui-preview-rows ui)
         (terminal-ui-stream-tail ui)))))
+
+(-> terminal-ui--status-row-visible-p (terminal-ui) boolean)
+(defun terminal-ui--status-row-visible-p (ui)
+  "Return whether UI needs its persistent context or animated status row."
+  (not
+   (null
+    (or (terminal-ui--animated-status-row-p ui)
+        (terminal-ui-context-window ui)))))
 
 (-> terminal-ui--activity-row-budget (terminal-ui) (integer 1))
 (defun terminal-ui--activity-row-budget (ui)
@@ -1557,15 +1568,17 @@ columns: name, tally, and description."
     (terminal-ui real)
     (option list))
 (defun terminal-ui--animation-signature-at (ui now)
-  "Return visible status, compaction, command, and child values for a live paint."
+  "Return visible status, compaction, command, child, and context values."
   (let ((commands (terminal-ui--command-presentation-activities ui))
         (agents (terminal-ui-agent-activities ui))
-        (compacting-p (terminal-ui-compacting-p ui)))
+        (compacting-p (terminal-ui-compacting-p ui))
+        (animated-p (terminal-ui--animated-status-row-p ui)))
     (when (terminal-ui--status-row-visible-p ui)
       (list
-       (list (terminal-ui-status ui)
-             (terminal-ui-local-activity ui)
-             (terminal-ui--status-signature-at ui now))
+       (and animated-p
+            (list (terminal-ui-status ui)
+                  (terminal-ui-local-activity ui)
+                  (terminal-ui--status-signature-at ui now)))
        (and compacting-p
             (terminal-ui--compaction-phase-at
              ui now (max 1 (terminal-columns (terminal-ui-terminal ui)))))
@@ -1584,7 +1597,11 @@ columns: name, tally, and description."
                                (getf activity :state))
                         :test #'eq)
                   (terminal-ui--agent-spinner-phase-at now))
-             agents))))))
+             agents))
+       (and (terminal-ui-context-window ui)
+            (list (terminal-ui-context-used ui)
+                  (terminal-ui-context-window ui)
+                  (terminal-ui-context-compaction-limit ui)))))))
 
 (-> terminal-ui--status-text-at (terminal-ui real) string)
 (defun terminal-ui--status-text-at (ui now)
@@ -1608,6 +1625,108 @@ columns: name, tally, and description."
               (terminal-span ':status-plain
                              (terminal-ui--duration-text
                               (+ worked-seconds elapsed))))))))
+
+(-> terminal-ui--context-count-text ((integer 0)) string)
+(defun terminal-ui--context-count-text (count)
+  "Return token COUNT as a short whole-number context quantity."
+  (cond
+    ((< count 1000)
+     (format nil "~D" count))
+    ((< count 1000000)
+     (format nil "~DK" (floor (+ count 500) 1000)))
+    (t
+     (let ((decimal (format nil "~,2F" (/ count 1000000))))
+       (format nil "~AM" (string-right-trim "0." decimal))))))
+
+(-> terminal-ui--context-compact-text (terminal-ui) string)
+(defun terminal-ui--context-compact-text (ui)
+  "Return UI's complete compact used/window context count."
+  (format nil "~A/~A"
+          (terminal-ui--context-count-text (terminal-ui-context-used ui))
+          (terminal-ui--context-count-text (terminal-ui-context-window ui))))
+
+(-> terminal-ui--context-track-spans (terminal-ui (integer 1)) list)
+(defun terminal-ui--context-track-spans (ui track-width)
+  "Return a used capacity track with UI's compaction marker."
+  (let* ((used (min (terminal-ui-context-used ui)
+                    (terminal-ui-context-window ui)))
+         (window (terminal-ui-context-window ui))
+         (limit (terminal-ui-context-compaction-limit ui))
+         (used-cells (min track-width
+                          (round (* used track-width) window)))
+         (marker-at (min track-width
+                         (round (* limit track-width) window))))
+    (labels ((segment-spans (start end)
+               "Return used and remaining spans from START through END."
+               (let* ((width (- end start))
+                      (used-width (max 0 (- (min used-cells end) start)))
+                      (remaining-width (- width used-width)))
+                 (append
+                  (when (plusp used-width)
+                    (list
+                     (terminal-span
+                      ':status-accent
+                      (make-string used-width :initial-element #\=))))
+                  (when (plusp remaining-width)
+                    (list
+                     (terminal-span
+                      ':status-dim
+                      (make-string remaining-width :initial-element #\.))))))))
+      (append
+       (list (terminal-span ':status-dim "["))
+       (segment-spans 0 marker-at)
+       (list (terminal-span ':status-plain "|"))
+       (segment-spans marker-at track-width)
+       (list (terminal-span ':status-dim "]"))))))
+
+(-> terminal-ui--context-meter-spans (terminal-ui integer) list)
+(defun terminal-ui--context-meter-spans (ui maximum-width)
+  "Return UI's largest context meter variant fitting MAXIMUM-WIDTH cells."
+  (let ((used (terminal-ui-context-used ui))
+        (window (terminal-ui-context-window ui))
+        (limit (terminal-ui-context-compaction-limit ui)))
+    (when (and used window limit (plusp maximum-width))
+      (let* ((used-text (terminal-ui--context-count-text used))
+             (window-text (terminal-ui--context-count-text window))
+             (full-prefix "ctx ")
+             (full-suffix
+               (format nil " ~A / ~A used" used-text window-text))
+             (compact-prefix "")
+             (compact-suffix
+               (format nil " ~A" (terminal-ui--context-compact-text ui)))
+             (full-fixed-width
+               (+ (text-cell-width full-prefix)
+                  3
+                  (text-cell-width full-suffix)))
+             (compact-fixed-width
+               (+ 3 (text-cell-width compact-suffix))))
+        (labels ((meter-spans (prefix suffix fixed-width)
+                   "Return a context meter using its available track width."
+                   (let ((track-width
+                           (min *terminal-ui-context-track-cells*
+                                (- maximum-width fixed-width))))
+                     (append
+                      (when (plusp (length prefix))
+                        (list (terminal-span ':status-dim prefix)))
+                      (terminal-ui--context-track-spans ui track-width)
+                      (list (terminal-span ':status-dim suffix))))))
+          (cond
+            ((>= maximum-width (+ full-fixed-width 4))
+             (meter-spans full-prefix full-suffix full-fixed-width))
+            ((>= maximum-width (+ compact-fixed-width 4))
+             (meter-spans compact-prefix compact-suffix compact-fixed-width))
+            ((>= maximum-width
+                 (text-cell-width (format nil "ctx~A" compact-suffix)))
+             (list (terminal-span ':status-dim
+                                  (format nil "ctx~A" compact-suffix))))
+            ((>= maximum-width (1- (text-cell-width compact-suffix)))
+             (list (terminal-span ':status-dim
+                                  (subseq compact-suffix 1))))
+            (t
+             (terminal--clip-spans
+              (list (terminal-span ':status-dim
+                                   (format nil "ctx~A" compact-suffix)))
+              maximum-width))))))))
 
 (-> terminal-ui--compaction-head-text ((integer 1)) string)
 (defun terminal-ui--compaction-head-text (width)
@@ -1657,36 +1776,102 @@ columns: name, tally, and description."
 
 (-> terminal-ui--status-row-at (terminal-ui real integer) list)
 (defun terminal-ui--status-row-at (ui now row-width)
-  "Return UI's clipped status spans padded across ROW-WIDTH cells.
+  "Return UI's clipped status and context spans across ROW-WIDTH cells.
 
-Total worked time is right-aligned when it fits beside the activity
-content; a narrow row drops it before any activity detail."
-  (let* ((content
-           (append
-            (terminal-ui--status-spinner-spans-at ui now)
-            (list (terminal-span ':status-accent " ∙ ")
-                  (terminal-span ':status-dim
-                                 (terminal-ui--status-text-at ui now)))
-            (terminal-ui-status-details ui)))
-         (clipped (terminal--clip-spans content row-width))
-         (left-width (terminal--spans-width clipped))
-         (worked (terminal-ui--worked-spans-at ui now))
-         (gap (- row-width left-width (terminal--spans-width worked)))
-         (padding (and (terminal-styled-p (terminal-ui-terminal ui))
-                       (- row-width left-width))))
+The context meter is right-aligned. Narrow rows reserve their available cells
+for its complete used/window count before showing activity. Total worked time
+joins the meter when every segment fits."
+  (let* ((animated-p (terminal-ui--animated-status-row-p ui))
+         (content
+           (and animated-p
+                (append
+                 (terminal-ui--status-spinner-spans-at ui now)
+                 (list (terminal-span ':status-accent " ∙ ")
+                       (terminal-span ':status-dim
+                                      (terminal-ui--status-text-at ui now)))
+                 (terminal-ui-status-details ui))))
+         (minimum-activity-width (text-cell-width "READ  ∙ 00:00"))
+         (complete-context-width
+           (and (terminal-ui-context-window ui)
+                (text-cell-width (terminal-ui--context-compact-text ui))))
+         (context-gap
+           (if (and content
+                    complete-context-width
+                    (< row-width
+                       (+ minimum-activity-width complete-context-width 2)))
+               1
+               2))
+         (activity-context-budget
+           (- row-width minimum-activity-width context-gap))
+         (context
+           (and (terminal-ui-context-window ui)
+                (terminal-ui--context-meter-spans
+                 ui
+                 (if (and content
+                          (>= activity-context-budget
+                              (text-cell-width
+                               (terminal-ui--context-compact-text ui))))
+                     activity-context-budget
+                     row-width))))
+         (worked (and content (terminal-ui--worked-spans-at ui now))))
     (cond
-      ((and worked (>= gap 2))
-       (append clipped
-               (list (terminal-span ':status-plain
-                                    (make-string gap :initial-element #\Space)))
-               worked))
-      ((and padding (plusp padding))
-       (append clipped
-               (list (terminal-span ':status-plain
-                                    (make-string padding
-                                                 :initial-element #\Space)))))
+      (context
+       (let* ((context-width (terminal--spans-width context))
+              (activity-space (- row-width context-width context-gap))
+              (activity-p (and content
+                               (>= activity-space minimum-activity-width)))
+              (worked-with-context-p
+                (and activity-p
+                     worked
+                     (<= (+ (terminal--spans-width content)
+                            2
+                            (terminal--spans-width worked)
+                            2
+                            context-width)
+                         row-width)))
+              (right
+                (if worked-with-context-p
+                    (append worked
+                            (list (terminal-span ':status-plain "  "))
+                            context)
+                    context))
+              (right-width (terminal--spans-width right))
+              (left-limit
+                (if activity-p
+                    (max 0 (- row-width right-width context-gap))
+                    0))
+              (left (and activity-p
+                         (terminal--clip-spans content left-limit)))
+              (padding (- row-width
+                          (terminal--spans-width left)
+                          right-width)))
+         (append
+          left
+          (when (plusp padding)
+            (list (terminal-span
+                   ':status-plain
+                   (make-string padding :initial-element #\Space))))
+          right)))
       (t
-       clipped))))
+       (let* ((clipped (terminal--clip-spans content row-width))
+              (left-width (terminal--spans-width clipped))
+              (gap (- row-width left-width (terminal--spans-width worked)))
+              (padding (and (terminal-styled-p (terminal-ui-terminal ui))
+                            (- row-width left-width))))
+         (cond
+           ((and worked (>= gap 2))
+            (append clipped
+                    (list (terminal-span
+                           ':status-plain
+                           (make-string gap :initial-element #\Space)))
+                    worked))
+           ((and padding (plusp padding))
+            (append clipped
+                    (list (terminal-span
+                           ':status-plain
+                           (make-string padding :initial-element #\Space)))))
+           (t
+            clipped)))))))
 
 (-> terminal-ui--local-activity-row (terminal-ui integer) list)
 (defun terminal-ui--local-activity-row (ui row-width)
@@ -2564,6 +2749,30 @@ seen can offer the notice again."
                        (terminal-ui-notice-deadline ui) nil)
                  (terminal-ui--paint-live ui)))))))
     (values ui applied-p)))
+
+(-> terminal-ui-set-context-usage
+    (terminal-ui
+     &key (:used (integer 0)) (:window (integer 1))
+          (:compaction-limit (integer 1)))
+    terminal-ui)
+(defun terminal-ui-set-context-usage (ui &key used window compaction-limit)
+  "Set UI's provider-reported context usage, window, and compaction limit."
+  (unless (<= compaction-limit window)
+    (error 'terminal-error
+           :message "The context compaction limit cannot exceed its window."
+           :operation ':set-context-usage
+           :cause nil))
+  (with-terminal-ui-locked (ui)
+    (unless (equal (list used window compaction-limit)
+                   (list (terminal-ui-context-used ui)
+                         (terminal-ui-context-window ui)
+                         (terminal-ui-context-compaction-limit ui)))
+      (setf (terminal-ui-context-used ui) used
+            (terminal-ui-context-window ui) window
+            (terminal-ui-context-compaction-limit ui) compaction-limit)
+      (when (terminal-ui-started-p ui)
+        (terminal-ui--paint-live ui))))
+  ui)
 
 (-> terminal-ui-set-compacting (terminal-ui boolean) terminal-ui)
 (defun terminal-ui-set-compacting (ui compacting-p)

--- a/tests/application-tests.lisp
+++ b/tests/application-tests.lisp
@@ -2497,7 +2497,12 @@
                (list 'configuration-create
                      (lambda (&rest arguments)
                        (declare (ignore arguments))
-                       configuration)))
+                       configuration))
+               (list 'application-terminal-ui-create
+                     (lambda ()
+                       (terminal-ui-create
+                        :terminal
+                        (make-instance 'recording-terminal :columns 80)))))
               (lambda ()
                 (setf application (application-create configuration))
                 (test-assert
@@ -2509,6 +2514,21 @@
                   (= (application-rendered-sequence application) 2)
                   (= (application-history-floor-sequence application) 1))
                  "clean-source recovery restores its conversation and cursors")
+                (let ((ui (application-ui application)))
+                  (test-assert
+                    (and (zerop (terminal-ui-context-used ui))
+                         (= (terminal-ui-context-window ui) 272000)
+                         (= (terminal-ui-context-compaction-limit ui) 217600))
+                   "application creation seeds its idle context meter")
+                  (test-assert (null (recording-terminal-chunks
+                                      (terminal-ui-terminal ui)))
+                               "seeding an unstarted meter does not paint")
+                  (terminal-ui-start ui)
+                   (test-assert (search "272K"
+                                        (recording-terminal-output
+                                         (terminal-ui-terminal ui)))
+                               "the first application paint includes its context meter")
+                  (terminal-ui-stop ui))
                 (publish-recovery-context)
                 (setf application
                       (application-reconnect
@@ -2533,7 +2553,22 @@
                    (conversation-identifier recovered))
                   (= (application-rendered-sequence application) 2)
                   (= (application-history-floor-sequence application) 1))
-                 "retained-generation reconnect restores recovery state"))))
+                 "retained-generation reconnect restores recovery state")
+                (let ((ui (application-ui application)))
+                  (test-assert
+                    (and (zerop (terminal-ui-context-used ui))
+                         (= (terminal-ui-context-window ui) 272000)
+                         (= (terminal-ui-context-compaction-limit ui) 217600))
+                   "application reconnect seeds its idle context meter")
+                  (test-assert (null (recording-terminal-chunks
+                                      (terminal-ui-terminal ui)))
+                               "reconnect seeding does not paint an unstarted UI")
+                  (terminal-ui-start ui)
+                   (test-assert (search "272K"
+                                        (recording-terminal-output
+                                         (terminal-ui-terminal ui)))
+                               "the first reconnect paint includes its context meter")
+                  (terminal-ui-stop ui)))))
         (close-application)
         (dolist (entry previous-environment)
           (if (rest entry)
@@ -3024,9 +3059,21 @@
          (progn
            (terminal-ui-start ui)
            (conversation-append-user-message conversation "history to compact")
+           (setf (conversation-last-total-tokens conversation) 262500)
+           (application-refresh-context-meter application)
+           (test-assert
+             (and (= (terminal-ui-context-used ui) 262500)
+                  (= (terminal-ui-context-window ui) 272000)
+                  (= (terminal-ui-context-compaction-limit ui) 217600))
+            "application refresh projects current provider usage into the idle meter")
            (let* ((observer (application-agent-observer application))
                   (send-status
                     (callback-agent-observer-status-callback observer)))
+             (setf (conversation-last-total-tokens conversation) 525000)
+             (funcall send-status :provider-request-completed nil)
+             (test-assert (= (terminal-ui-context-used ui) 525000)
+                          "provider completion refreshes the context meter")
+             (setf (conversation-last-total-tokens conversation) 262500)
              (funcall send-status :compaction-started nil)
              (test-assert
               (and (terminal-ui-compacting-p ui)
@@ -3038,9 +3085,12 @@
                (declare (ignore display cursor))
                (test-assert (search "COMPACTING  [====>" text)
                             "the application observer projects compaction live"))
+             (setf (conversation-last-total-tokens conversation) 0)
              (funcall send-status :compaction-completed nil)
              (test-assert (not (terminal-ui-compacting-p ui))
                           "completion removes the compaction indicator")
+             (test-assert (zerop (terminal-ui-context-used ui))
+                          "compaction completion refreshes the context meter")
              (funcall send-status :compaction-started nil)
              (funcall send-status :turn-completed nil)
              (test-assert (and (not (terminal-ui-compacting-p ui))
@@ -4934,7 +4984,10 @@
                                  :tool-registry registry
                                  :worker worker-pool
                                  :agent agent
-                                 :ui nil))
+                                 :ui
+                                 (terminal-ui-create
+                                  :terminal
+                                  (make-instance 'recording-terminal :columns 80))))
                 (worker nil))
            (setf pool worker-pool
                  closable-application application
@@ -4983,6 +5036,18 @@
                        (application-provider application)))
                      (truename workspace))
               "workspace switching reconnects the provider with the new directory")
+             (let ((ui (application-ui application))
+                   (active-configuration
+                     (application-configuration application)))
+              (test-assert
+               (and (= (terminal-ui-context-used ui)
+                       (conversation-last-total-tokens conversation))
+                    (= (terminal-ui-context-window ui)
+                       (configuration-context-window active-configuration))
+                    (= (terminal-ui-context-compaction-limit ui)
+                       (configuration-compaction-token-limit
+                        active-configuration)))
+               "workspace switching refreshes the context meter after replacement"))
               (test-assert
                (eq
                 (mcp-server-registration-source

--- a/tests/mcp-tool-tests.lisp
+++ b/tests/mcp-tool-tests.lisp
@@ -1310,6 +1310,20 @@
                                 application))
                               "cleanup failure leaves the replacement runtime live")
                              (test-assert
+                              (let ((ui (application-ui application))
+                                    (configuration
+                                      (application-configuration application)))
+                                (and
+                                  (= (terminal-ui-context-used ui)
+                                     (conversation-last-total-tokens
+                                      (application-conversation application)))
+                                  (= (terminal-ui-context-window ui)
+                                     (configuration-context-window configuration))
+                                  (= (terminal-ui-context-compaction-limit ui)
+                                     (configuration-compaction-token-limit
+                                      configuration))))
+                              "committed MCP reload refreshes the context meter")
+                             (test-assert
                               (and
                                (find
                                 "mcp-reload-late-new-context"

--- a/tests/terminal-tests.lisp
+++ b/tests/terminal-tests.lisp
@@ -832,6 +832,140 @@
      "protocol shutdown continues after one cleanup write fails"))
   nil)
 
+(-> test-terminal-context-meter () null)
+(defun test-terminal-context-meter ()
+  "Test the persistent context meter, threshold marker, and narrow presentation."
+  (flet ((row-text (ui width)
+           (format nil "~{~A~}"
+                   (mapcar #'terminal-span-text
+                           (terminal-ui--status-row-at ui 0 width)))))
+    (let* ((terminal (make-instance 'recording-terminal :columns 120))
+           (ui (terminal-ui-create :terminal terminal)))
+      (with-terminal-ui (active-ui ui)
+        (terminal-ui-set-context-usage active-ui
+                                       :used 0
+                                       :window 1050000
+                                       :compaction-limit 840000)
+        (test-assert (terminal-ui--status-row-visible-p active-ui)
+                     "context usage keeps the modeline visible while idle")
+        (test-assert
+         (search "ctx [..........|..] 0 / 1.05M used"
+                 (row-text active-ui 120))
+         "an empty context meter shows its full window and compaction marker")
+        (terminal-ui-set-context-usage active-ui
+                                       :used 262500
+                                       :window 1050000
+                                       :compaction-limit 840000)
+        (test-assert
+         (search "ctx [===.......|..] 263K / 1.05M used"
+                 (row-text active-ui 120))
+         "a quarter-full context meter shows used and window tokens")
+        (terminal-ui-set-context-usage active-ui
+                                       :used 840000
+                                       :window 1050000
+                                       :compaction-limit 840000)
+        (test-assert
+         (search "ctx [==========|..] 840K / 1.05M used"
+                 (row-text active-ui 120))
+         "the meter marks the automatic compaction threshold")
+        (terminal-ui-set-context-usage active-ui
+                                       :used 262500
+                                       :window 1050000
+                                       :compaction-limit 840000)
+        (terminal-ui-set-status active-ui "working")
+        (let ((wide (row-text active-ui 120)))
+          (test-assert (search "READ  ∙ 00:00" wide)
+                       "a wide context row retains live activity")
+          (test-assert
+           (search "ctx [===.......|..] 263K / 1.05M used" wide)
+           "a wide context row retains the full meter")
+          (test-assert
+           (let ((start (search "ctx [===.......|..] 263K / 1.05M used" wide)))
+             (and start
+                  (= (+ start (length "ctx [===.......|..] 263K / 1.05M used"))
+                     (length wide))))
+           "a wide context meter is right-aligned"))
+        (dolist (width '(25 30 33))
+          (let ((intermediate (row-text active-ui width)))
+            (test-assert (search "READ  ∙ 00:00" intermediate)
+                         (format nil
+                                 "an active ~D-column meter retains minimum activity"
+                                 width))
+            (test-assert (search "263K/1.05M" intermediate)
+                         (format nil
+                                 "an active ~D-column meter retains complete counts"
+                                 width))
+            (test-assert (<= (text-cell-width intermediate) width)
+                         (format nil
+                                 "an active ~D-column meter never overflows its row"
+                                 width))))
+        (let ((intermediate (row-text active-ui 30)))
+          (test-assert (search "ctx 263K/1.05M" intermediate)
+                       "a 30-column meter retains labelled compact context"))
+        (let ((intermediate (row-text active-ui 33)))
+          (test-assert (search "[=..|.] 263K/1.05M" intermediate)
+                       "a 33-column meter selects the largest compact bar"))
+        (terminal-ui-set-context-usage active-ui
+                                       :used 1050000
+                                       :window 1050000
+                                       :compaction-limit 840000)
+        (dolist (width '(24 25 26 27 28 29 30 31 32 33))
+          (let ((high-usage (row-text active-ui width)))
+            (test-assert (search "1.05M/1.05M" high-usage)
+                         (format nil
+                                 "a high-usage ~D-column meter retains complete counts"
+                                 width))
+            (test-assert (<= (text-cell-width high-usage) width)
+                         (format nil
+                                 "a high-usage ~D-column meter never overflows its row"
+                                 width))))
+        (let ((too-narrow (row-text active-ui 24))
+              (minimum (row-text active-ui 25))
+              (preferred (row-text active-ui 26)))
+          (test-assert (not (search "READ  ∙ 00:00" too-narrow))
+                       "below the combined minimum, context displaces activity")
+          (test-assert
+           (string= minimum "READ  ∙ 00:00 1.05M/1.05M")
+           "the combined minimum uses a one-cell activity and context gap")
+          (test-assert
+           (string= preferred "READ  ∙ 00:00  1.05M/1.05M")
+           "the next width restores the preferred two-cell gap"))
+        (dolist (width '(25 26 27 28 29 30 31 32 33))
+          (test-assert (search "READ  ∙ 00:00" (row-text active-ui width))
+                       (format nil
+                               "a high-usage ~D-column meter retains activity"
+                               width)))
+        (terminal-ui-set-context-usage active-ui
+                                       :used 262500
+                                       :window 1050000
+                                       :compaction-limit 840000)
+        (dolist (width '(12 13))
+          (let ((narrow (row-text active-ui width)))
+            (test-assert (and (search "263K/1.05M" narrow)
+                              (not (search "ctx" narrow)))
+                         (format nil
+                                 "an active ~D-column meter retains used and window tokens"
+                                 width))
+            (test-assert (<= (text-cell-width narrow) width)
+                         (format nil
+                                 "an active ~D-column meter never overflows its row"
+                                 width))))
+        (let ((narrow (row-text active-ui 14)))
+          (test-assert (string= narrow "ctx 263K/1.05M")
+                       "an active 14-column meter retains its context label")
+          (test-assert (<= (text-cell-width narrow) 14)
+                       "an active 14-column meter never overflows its row"))
+        (let ((narrow (row-text active-ui 10)))
+          (test-assert (string= narrow "263K/1.05M")
+                       "an active 10-column meter retains its complete counts"))
+        (dolist (width '(1 2 9))
+          (let ((narrow (row-text active-ui width)))
+            (test-assert (<= (text-cell-width narrow) width)
+                         (format nil
+                                 "only sub-count widths clip an active meter at ~D columns"
+                                 width)))))))
+  nil)
+
 
 (-> test-terminal-bounded-editor-repaint () null)
 (defun test-terminal-bounded-editor-repaint ()
@@ -2525,6 +2659,7 @@ sources keeps the tests deterministic under an interactive terminal."
   (test-terminal-image-attachments)
   (test-terminal-input-decoding)
   (test-terminal-status-worked-time)
+  (test-terminal-context-meter)
   (test-terminal-bounded-editor-repaint)
   (test-terminal-transient-notice)
   (test-terminal-notice-lock-contention)

--- a/tests/test-support.lisp
+++ b/tests/test-support.lisp
@@ -114,6 +114,8 @@
                    :grok-bootstrap-auth-path
                    (merge-pathnames "missing-grok-auth.json" root)
                    :model *default-model*
+                   :context-window (configuration--context-window-for
+                                    *default-model*)
                    :reasoning-effort *default-reasoning-effort*
                    :provider-endpoint *codex-responses-endpoint*)))
 (-> test-configuration-root (configuration) pathname)

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -57,14 +57,23 @@
                           "gpt-5.6-luna")
                  "model copies swap only the model")
     (test-assert (= (configuration-context-window configuration) 272000)
-                 "5.6 models carry the live catalog context window")
+                 "5.6 subscription models carry the verified Codex window")
     (test-assert (= (configuration-context-window
                      (configuration-with-model configuration "gpt-5.6-terra"))
                     272000)
                  "model copies recompute the context window")
+    (test-assert (= *default-context-window* 272000)
+                 "unknown models retain the conservative context window fallback")
     (test-assert (= (configuration-compaction-token-limit configuration)
                     217600)
                  "compaction triggers at the threshold share of the window")
+    (dolist (model '("gpt-5.6-sol" "gpt-5.6-luna" "gpt-5.6-terra"))
+      (test-assert (= (rest (assoc model *model-context-windows*
+                                   :test #'string=))
+                      272000)
+                   "GPT-5.6 fallbacks use the verified Codex subscription window")
+      (test-assert (= (provider-model-context-window-for model) 272000)
+                   "GPT-5.6 ChatGPT metadata uses the subscription window"))
     (test-assert (handler-case
                      (progn
                        (configuration-with-model configuration "gpt-4")


### PR DESCRIPTION
## Summary

- show persistent live context usage and the compaction threshold in the terminal status row
- refresh the meter across provider completion, compaction, reconnect, configuration, and conversation changes
- use the verified 1.05M-token context window for GPT-5.6 Codex models
- preserve the compact meter on narrow terminals

## Verification

- delimiter checks pass for `src` and `tests`
- `run-terminal-tests` passes
- `run-application-tests` passes
- `./script/check` passes through the terminal and MCP coverage, then reaches the existing release-script archive-helper environment failure at `(truename nil)`