### PR TITLE
fix opencode provider auth interaction

### DIFF
--- a/src/provider/opencode/authentication.lisp
+++ b/src/provider/opencode/authentication.lisp
@@ -68,7 +68,9 @@
      &key
        (stream *standard-output*)
        (input *standard-input*)
-       input-file-descriptor)
+       (input-file-descriptor
+         (and (eq input *standard-input*)
+              *api-key-input-file-descriptor*)))
   "Prompt for an OpenCode API key and save it to MANAGER's private store.
 
 OpenCode's model-list endpoint is public, so login cannot validate a key without

--- a/tests/opencode-provider-tests.lisp
+++ b/tests/opencode-provider-tests.lisp
@@ -182,15 +182,15 @@
                    (setf save-secret-use-active-p (secret-use-active-p))
                    (funcall original-save source credentials))))
           (lambda ()
-            (test-assert
-             (string=
-              (opencode-api-key-login
-               manager
-               :stream (make-string-output-stream)
-               :input (make-string-input-stream "")
-               :input-file-descriptor 23)
-              "OpenCode authentication was saved by Autolith.")
-             "OpenCode login reports successful private persistence")
+            (let ((*api-key-input-file-descriptor* 23))
+              (test-assert
+               (string=
+                (opencode-api-key-login
+                 manager
+                 :stream (make-string-output-stream)
+                 :input *standard-input*)
+                "OpenCode authentication was saved by Autolith.")
+                "OpenCode login reports successful private persistence"))
             (setf stored
                   (credential-source-load
                    (credential-manager-primary-source manager)))))


### PR DESCRIPTION
There was an issue with the API key input when using the `autolith auth opencode` where it would skip over the input of the api key beacuse the handling of the input-file-descriptor was off.