### PR TITLE
Pin double-underscore wire name round-trip

### DIFF
--- a/src/provider/wire-protocol.lisp
+++ b/src/provider/wire-protocol.lisp
@@ -85,6 +85,9 @@
     (error ()
       nil)))
 
+;; The length prefix lets the decoder find the namespace boundary without
+;; ambiguity, so namespaces following the MCP convention of the form
+;; mcp__server, which themselves contain a double underscore, survive decode.
 (-> provider-wire-function-name--encode (string string) string)
 (defun provider-wire-function-name--encode (namespace name)
   "Encode NAMESPACE and NAME as one readable reversible function name."

--- a/tests/openai-compatible-provider-tests.lisp
+++ b/tests/openai-compatible-provider-tests.lisp
@@ -1314,6 +1314,13 @@
       (test-assert
        (and (equal namespace "mcp__demo") (equal name "call_name"))
        "readable OpenAI-compatible wire names round-trip")))
+  (let ((wire-name
+          (openai-compatible--wire-tool-name "mcp__server" "get__status")))
+    (multiple-value-bind (namespace name)
+        (openai-compatible--decode-wire-tool-name wire-name)
+      (test-assert
+       (and (equal namespace "mcp__server") (equal name "get__status"))
+       "namespaced wire names with double underscores in both halves round-trip")))
   (multiple-value-bind (namespace name)
       (openai-compatible--decode-wire-tool-name "acmVzb3VyY2UAcmVhZA")
     (test-assert


### PR DESCRIPTION
The OpenAI-compatible wire-name codec encodes namespaced tool names with a length-prefixed readable scheme (`t_<len>_<ns>__<name>`) so MCP namespaces of the form `mcp__server`, which themselves contain a double underscore, survive decode unambiguously.

The existing round-trip test covers `mcp__demo` / `call_name`, where only the namespace holds a double underscore. This adds the missing case where both the namespace and the tool name contain a double underscore (`mcp__server` / `get__status`), pinning the exact invariant the codec was designed to protect. It also restores the rationale comment that originally accompanied the wire-name functions.